### PR TITLE
Fix Windows handle leak 

### DIFF
--- a/sigar_windows.go
+++ b/sigar_windows.go
@@ -324,6 +324,7 @@ func GetParentPid(pid int) (int, error) {
 	if handle < 0 {
 		return 0, syscall.GetLastError()
 	}
+	defer syscall.CloseHandle(syscall.Handle(handle))
 
 	var entry PROCESSENTRY32
 	entry.Size = uint32(unsafe.Sizeof(entry))


### PR DESCRIPTION
Add a deferred close for the handle returned by CreateToolhelp32Snapshot on Windows. The handle points to a snapshot of the process'es information and was previously being leaked when getting ProcState.