### PR TITLE
Support spaces in process names.

### DIFF
--- a/concrete_sigar_test.go
+++ b/concrete_sigar_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	sigar "github.com/cloudfoundry/gosigar"
+	sigar "github.com/elastic/gosigar"
 )
 
 var _ = Describe("ConcreteSigar", func() {

--- a/sigar_interface_test.go
+++ b/sigar_interface_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	. "github.com/cloudfoundry/gosigar"
+	. "github.com/elastic/gosigar"
 )
 
 var _ = Describe("Sigar", func() {

--- a/sigar_linux.go
+++ b/sigar_linux.go
@@ -5,6 +5,8 @@ package sigar
 import (
 	"bufio"
 	"bytes"
+	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -198,7 +200,11 @@ func (self *ProcState) Get(pid int) error {
 	fields := strings.Fields(headerAndStats[1])
 
 	name := strings.SplitAfterN(pidAndName, " ", 2)[1]
-	self.Name = name[1 : len(name)-1] // strip ()'s
+	if name[0] == '(' && name[len(name)-1] == ')' {
+		self.Name = name[1 : len(name)-1] // strip ()'s
+	} else {
+		return errors.New(fmt.Sprintf("Malformed process stats for pid %d", pid))
+	}
 
 	self.State = RunState(fields[0][0])
 

--- a/sigar_linux.go
+++ b/sigar_linux.go
@@ -193,21 +193,24 @@ func (self *ProcState) Get(pid int) error {
 		return err
 	}
 
-	fields := strings.Fields(string(contents))
+	headerAndStats := strings.SplitAfterN(string(contents), ")", 2)
+	pidAndName := headerAndStats[0]
+	fields := strings.Fields(headerAndStats[1])
 
-	self.Name = fields[1][1 : len(fields[1])-1] // strip ()'s
+	name := strings.SplitAfterN(pidAndName, " ", 2)[1]
+	self.Name = name[1 : len(name)-1] // strip ()'s
 
-	self.State = RunState(fields[2][0])
+	self.State = RunState(fields[0][0])
 
-	self.Ppid, _ = strconv.Atoi(fields[3])
+	self.Ppid, _ = strconv.Atoi(fields[1])
 
-	self.Tty, _ = strconv.Atoi(fields[6])
+	self.Tty, _ = strconv.Atoi(fields[4])
 
-	self.Priority, _ = strconv.Atoi(fields[17])
+	self.Priority, _ = strconv.Atoi(fields[15])
 
-	self.Nice, _ = strconv.Atoi(fields[18])
+	self.Nice, _ = strconv.Atoi(fields[16])
 
-	self.Processor, _ = strconv.Atoi(fields[38])
+	self.Processor, _ = strconv.Atoi(fields[36])
 
 	return nil
 }


### PR DESCRIPTION
Hello,

This patch allows for spaces in process names on Linux.

Because everything was split on space, the process name would get truncated if it had spaces. I picked this up in Topbeat, where my `starman worker` processes were coming in as `starma`. This also messes up all the later fields in `/proc/[pid]/stat`, since they are all getting sliced out by position, and the index is off in this case.

I've not written a byte of Go before, so please forgive this patch. Hopefully you get the gist of it though.

Thanks.