### PR TITLE
Merge fix to stop failures on get CPUList

### DIFF
--- a/sigar_windows.go
+++ b/sigar_windows.go
@@ -127,7 +127,8 @@ func (self *Cpu) Get() error {
 }
 
 func (self *CpuList) Get() error {
-	return notImplemented()
+	//return notImplemented()
+	return nil
 }
 
 func (self *FileSystemList) Get() error {


### PR DESCRIPTION
Supporting patch for https://github.com/elastic/topbeat/pull/130

Get CPUList fails because it has a panic(). Suppressing it to get topbeat working.