### PR TITLE
use the elastic/gosigar package in examples

### DIFF
--- a/examples/df.go
+++ b/examples/df.go
@@ -4,7 +4,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/cloudfoundry/gosigar"
+	"github.com/elastic/gosigar"
 	"os"
 )
 

--- a/examples/free.go
+++ b/examples/free.go
@@ -4,7 +4,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/cloudfoundry/gosigar"
+	"github.com/elastic/gosigar"
 	"os"
 )
 

--- a/examples/ps.go
+++ b/examples/ps.go
@@ -4,7 +4,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/cloudfoundry/gosigar"
+	"github.com/elastic/gosigar"
 )
 
 func main() {

--- a/examples/uptime.go
+++ b/examples/uptime.go
@@ -4,7 +4,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/cloudfoundry/gosigar"
+	"github.com/elastic/gosigar"
 	"os"
 	"time"
 )


### PR DESCRIPTION
Even if `elastic/gosigar` is to be merged into `cloudfoundry/gosigar` at some point, it's helpful right now to build the examples against the "local" package.