### PR TITLE
Add GetProcCredName implementation to windows gosigar

### DIFF
--- a/sigar_interface.go
+++ b/sigar_interface.go
@@ -106,6 +106,7 @@ const (
 
 type ProcState struct {
 	Name      string
+	Username  string
 	State     RunState
 	Ppid      int
 	Tty       int

--- a/sigar_windows_test.go
+++ b/sigar_windows_test.go
@@ -3,6 +3,7 @@ package sigar_test
 import (
 	"math"
 	"os"
+	"os/user"
 	"strings"
 	"testing"
 
@@ -30,6 +31,18 @@ var _ = Describe("SigarWindows", func() {
 
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(usage.Total).Should(BeNumerically(">", 0))
+		})
+	})
+
+	Describe("Process", func() {
+		It("gets the current process user name", func() {
+			proc := sigar.ProcState{}
+			err := proc.Get(os.Getpid())
+			user, usererr := user.Current()
+
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(usererr).ShouldNot(HaveOccurred())
+			Ω(proc.Username).Should(Equal(user.Username))
 		})
 	})
 })


### PR DESCRIPTION
When collecting process information in windows, it is sometimes useful to know the process identity to disambiguate like process (web sites) or identify problem users on a system.

This can be implemented fairly simply with the win32 api bindings in go.

This is related to the topbeats issue elastic/beats#590 and elastic/topbeat#36, basically enables a simple call to gosigar from topbeat to implement.
