### PR TITLE
Set ProctState.Username on darwin and linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
   - osx
 
 go:
-  - 1.5.1
+  - 1.5.3
 
 env:
   global:

--- a/sigar_darwin.go
+++ b/sigar_darwin.go
@@ -20,6 +20,8 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"os/user"
+	"strconv"
 	"syscall"
 	"time"
 	"unsafe"
@@ -255,6 +257,15 @@ func (self *ProcState) Get(pid int) error {
 	self.Priority = int(info.ptinfo.pti_priority)
 
 	self.Nice = int(info.pbsd.pbi_nice)
+
+	// Get process username. Fallback to UID if username is not available.
+	uid := strconv.Itoa(int(info.pbsd.pbi_uid))
+	user, err := user.LookupId(uid)
+	if err == nil && user.Username != "" {
+		self.Username = user.Username
+	} else {
+		self.Username = uid
+	}
 
 	return nil
 }

--- a/sigar_test.go
+++ b/sigar_test.go
@@ -1,0 +1,29 @@
+// +build linux darwin windows
+
+package sigar_test
+
+import (
+	"os"
+	"os/user"
+	"testing"
+
+	sigar "github.com/elastic/gosigar"
+)
+
+func TestProcStateUsername(t *testing.T) {
+	proc := sigar.ProcState{}
+	err := proc.Get(os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	user, err := user.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if user.Username != proc.Username {
+		t.Fatalf("Usernames don't match, expected %s, but got %s",
+			user.Username, proc.Username)
+	}
+}


### PR DESCRIPTION
The PR enhances gosigar to set the `ProcState.Username` value for Linux and Darwin (Mac OSX).

elastic/topbeat#36

Linux reference: https://www.kernel.org/doc/Documentation/filesystems/proc.txt