### PR TITLE
remove getfsstat wrapper, the original issue has since been resolved

### DIFF
--- a/sigar_darwin.go
+++ b/sigar_darwin.go
@@ -165,14 +165,14 @@ func (self *CpuList) Get() error {
 }
 
 func (self *FileSystemList) Get() error {
-	num, err := getfsstat(nil, C.MNT_NOWAIT)
-	if num < 0 {
+	num, err := syscall.Getfsstat(nil, C.MNT_NOWAIT)
+	if err != nil {
 		return err
 	}
 
 	buf := make([]syscall.Statfs_t, num)
 
-	num, err = getfsstat(buf, C.MNT_NOWAIT)
+	_, err = syscall.Getfsstat(buf, C.MNT_NOWAIT)
 	if err != nil {
 		return err
 	}
@@ -439,30 +439,6 @@ func sysctlbyname(name string, data interface{}) (err error) {
 
 	bbuf := bytes.NewBuffer([]byte(val))
 	return binary.Read(bbuf, binary.LittleEndian, data)
-}
-
-// syscall.Getfsstat() wrapper is broken, roll our own to workaround.
-func getfsstat(buf []syscall.Statfs_t, flags int) (n int, err error) {
-	var ptr uintptr
-	var size uintptr
-
-	if len(buf) > 0 {
-		ptr = uintptr(unsafe.Pointer(&buf[0]))
-		size = unsafe.Sizeof(buf[0]) * uintptr(len(buf))
-	} else {
-		ptr = uintptr(0)
-		size = uintptr(0)
-	}
-
-	trap := uintptr(syscall.SYS_GETFSSTAT64)
-	ret, _, errno := syscall.Syscall(trap, ptr, size, uintptr(flags))
-
-	n = int(ret)
-	if errno != 0 {
-		err = errno
-	}
-
-	return
 }
 
 func task_info(pid int, info *C.struct_proc_taskallinfo) error {


### PR DESCRIPTION
The original issue appears to have been: https://github.com/golang/go/issues/6588 , but that was resolved in Go 1.3.

I've verified the workaround is no longer required on `go1.6 darwin/amd64` and in the upcoming OpenBSD backend on `go1.5.3 openbsd/amd64`