### PR TITLE
Initial OpenBSD support

### DIFF
--- a/sigar_openbsd.go
+++ b/sigar_openbsd.go
@@ -1,0 +1,343 @@
+// Copyright (c) 2016 Jasper Lievisse Adriaanse <j@jasper.la>.
+
+// +build openbsd
+
+package gosigar
+
+/*
+#include <sys/param.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <sys/mount.h>
+#include <sys/sched.h>
+#include <sys/swap.h>
+#include <stdlib.h>
+#include <unistd.h>
+*/
+import "C"
+
+//import "github.com/davecgh/go-spew/spew"
+
+import (
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+type Uvmexp struct {
+	pagesize           uint32
+	pagemask           uint32
+	pageshift          uint32
+	npages             uint32
+	free               uint32
+	active             uint32
+	inactive           uint32
+	paging             uint32
+	wired              uint32
+	zeropages          uint32
+	reserve_pagedaemon uint32
+	reserve_kernel     uint32
+	anonpages          uint32
+	vnodepages         uint32
+	vtextpages         uint32
+	freemin            uint32
+	freetarg           uint32
+	inactarg           uint32
+	wiredmax           uint32
+	anonmin            uint32
+	vtextmin           uint32
+	vnodemin           uint32
+	anonminpct         uint32
+	vtextmi            uint32
+	npct               uint32
+	vnodeminpct        uint32
+	nswapdev           uint32
+	swpages            uint32
+	swpginuse          uint32
+	swpgonly           uint32
+	nswget             uint32
+	nanon              uint32
+	nanonneeded        uint32
+	nfreeanon          uint32
+	faults             uint32
+	traps              uint32
+	intrs              uint32
+	swtch              uint32
+	softs              uint32
+	syscalls           uint32
+	pageins            uint32
+	obsolete_swapins   uint32
+	obsolete_swapouts  uint32
+	pgswapin           uint32
+	pgswapout          uint32
+	forks              uint32
+	forks_ppwait       uint32
+	forks_sharevm      uint32
+	pga_zerohit        uint32
+	pga_zeromiss       uint32
+	zeroaborts         uint32
+	fltnoram           uint32
+	fltnoanon          uint32
+	fltpgwait          uint32
+	fltpgrele          uint32
+	fltrelck           uint32
+	fltrelckok         uint32
+	fltanget           uint32
+	fltanretry         uint32
+	fltamcopy          uint32
+	fltnamap           uint32
+	fltnomap           uint32
+	fltlget            uint32
+	fltget             uint32
+	flt_anon           uint32
+	flt_acow           uint32
+	flt_obj            uint32
+	flt_prcopy         uint32
+	flt_przero         uint32
+	pdwoke             uint32
+	pdrevs             uint32
+	pdswout            uint32
+	pdfreed            uint32
+	pdscans            uint32
+	pdanscan           uint32
+	pdobscan           uint32
+	pdreact            uint32
+	pdbusy             uint32
+	pdpageouts         uint32
+	pdpending          uint32
+	pddeact            uint32
+	pdreanon           uint32
+	pdrevnode          uint32
+	pdrevtext          uint32
+	fpswtch            uint32
+	kmapent            uint32
+}
+
+type Bcachestats struct {
+	numbufs        uint64
+	numbufpages    uint64
+	numdirtypages  uint64
+	numcleanpages  uint64
+	pendingwrites  uint64
+	pendingreads   uint64
+	numwrites      uint64
+	numreads       uint64
+	cachehits      uint64
+	busymapped     uint64
+	dmapages       uint64
+	highpages      uint64
+	delwribufs     uint64
+	kvaslots       uint64
+	kvaslots_avail uint64
+}
+
+type Swapent struct {
+	se_dev      C.dev_t
+	se_flags    int32
+	se_nblks    int32
+	se_inuse    int32
+	se_priority int32
+	sw_path     []byte
+}
+
+func (self *FileSystemList) Get() error {
+	num, err := syscall.Getfsstat(nil, C.MNT_NOWAIT)
+	if err != nil {
+		return err
+	}
+
+	buf := make([]syscall.Statfs_t, num)
+
+	_, err = syscall.Getfsstat(buf, C.MNT_NOWAIT)
+	if err != nil {
+		return err
+	}
+
+	fslist := make([]FileSystem, 0, num)
+
+	for i := 0; i < num; i++ {
+		fs := FileSystem{}
+
+		fs.DirName = bytePtrToString(&buf[i].F_mntonname[0])
+		fs.DevName = bytePtrToString(&buf[i].F_mntfromname[0])
+		fs.SysTypeName = bytePtrToString(&buf[i].F_fstypename[0])
+
+		fslist = append(fslist, fs)
+	}
+
+	self.List = fslist
+
+	return err
+}
+
+func (self *FileSystemUsage) Get(path string) error {
+	stat := syscall.Statfs_t{}
+	err := syscall.Statfs(path, &stat)
+	if err != nil {
+		return err
+	}
+
+	self.Total = uint64(stat.F_blocks) * uint64(stat.F_bsize)
+	self.Free = uint64(stat.F_bfree) * uint64(stat.F_bsize)
+	self.Avail = uint64(stat.F_bavail) * uint64(stat.F_bsize)
+	self.Used = self.Total - self.Free
+	self.Files = stat.F_files
+	self.FreeFiles = stat.F_ffree
+
+	return nil
+}
+
+func (self *LoadAverage) Get() error {
+	avg := []C.double{0, 0, 0}
+
+	C.getloadavg(&avg[0], C.int(len(avg)))
+
+	self.One = float64(avg[0])
+	self.Five = float64(avg[1])
+	self.Fifteen = float64(avg[2])
+
+	return nil
+}
+
+func (self *Uptime) Get() error {
+	tv := syscall.Timeval{}
+	mib := [2]int32{C.CTL_KERN, C.KERN_BOOTTIME}
+
+	n := uintptr(0)
+	// First we determine how much memory we'll need to pass later on (via `n`)
+	_, _, errno := syscall.Syscall6(syscall.SYS___SYSCTL, uintptr(unsafe.Pointer(&mib[0])), 2, 0, uintptr(unsafe.Pointer(&n)), 0, 0)
+
+	if errno != 0 || n == 0 {
+		return nil
+	}
+
+	// Now perform the actual sysctl(3) call, storing the result in tv
+	_, _, errno = syscall.Syscall6(syscall.SYS___SYSCTL, uintptr(unsafe.Pointer(&mib[0])), 2, uintptr(unsafe.Pointer(&tv)), uintptr(unsafe.Pointer(&n)), 0, 0)
+
+	if errno != 0 || n == 0 {
+		return nil
+	}
+
+	self.Length = time.Since(time.Unix(int64(tv.Sec), int64(tv.Usec)*1000)).Seconds()
+
+	return nil
+}
+
+func (self *Mem) Get() error {
+	n := uintptr(0)
+
+	var uvmexp Uvmexp
+	mib := [2]int32{C.CTL_VM, C.VM_UVMEXP}
+	n = uintptr(0)
+	// First we determine how much memory we'll need to pass later on (via `n`)
+	_, _, errno := syscall.Syscall6(syscall.SYS___SYSCTL, uintptr(unsafe.Pointer(&mib[0])), 2, 0, uintptr(unsafe.Pointer(&n)), 0, 0)
+	if errno != 0 || n == 0 {
+		return nil
+	}
+
+	_, _, errno = syscall.Syscall6(syscall.SYS___SYSCTL, uintptr(unsafe.Pointer(&mib[0])), 2, uintptr(unsafe.Pointer(&uvmexp)), uintptr(unsafe.Pointer(&n)), 0, 0)
+	if errno != 0 || n == 0 {
+		return nil
+	}
+
+	var bcachestats Bcachestats
+	mib3 := [3]int32{C.CTL_VFS, C.VFS_GENERIC, C.VFS_BCACHESTAT}
+	n = uintptr(0)
+	_, _, errno = syscall.Syscall6(syscall.SYS___SYSCTL, uintptr(unsafe.Pointer(&mib3[0])), 3, 0, uintptr(unsafe.Pointer(&n)), 0, 0)
+	if errno != 0 || n == 0 {
+		return nil
+	}
+	_, _, errno = syscall.Syscall6(syscall.SYS___SYSCTL, uintptr(unsafe.Pointer(&mib3[0])), 3, uintptr(unsafe.Pointer(&bcachestats)), uintptr(unsafe.Pointer(&n)), 0, 0)
+	if errno != 0 || n == 0 {
+		return nil
+	}
+
+	self.Total = uint64(uvmexp.npages) << uvmexp.pageshift
+	self.Used = uint64(uvmexp.npages-uvmexp.free) << uvmexp.pageshift
+	self.Free = uint64(uvmexp.free) << uvmexp.pageshift
+
+	self.ActualFree = self.Free + (uint64(bcachestats.numbufpages) << uvmexp.pageshift)
+	self.ActualUsed = self.Used - (uint64(bcachestats.numbufpages) << uvmexp.pageshift)
+
+	return nil
+}
+
+func (self *Swap) Get() error {
+	nswap := C.swapctl(C.SWAP_NSWAP, unsafe.Pointer(uintptr(0)), 0)
+
+	// If there are no swap devices, nothing to do here.
+	if nswap == 0 {
+		return nil
+	}
+
+	swdev := make([]Swapent, nswap)
+
+	rnswap := C.swapctl(C.SWAP_STATS, unsafe.Pointer(&swdev[0]), nswap)
+	if rnswap == 0 {
+		return nil
+	}
+
+	for i := 0; i < int(nswap); i++ {
+		if swdev[i].se_flags&C.SWF_ENABLE == 2 {
+			self.Used = self.Used + uint64(swdev[i].se_inuse/(1024/C.DEV_BSIZE))
+			self.Total = self.Total + uint64(swdev[i].se_nblks/(1024/C.DEV_BSIZE))
+		}
+	}
+
+	self.Free = self.Total - self.Used
+
+	return nil
+}
+
+func (self *Cpu) Get() error {
+	load := [C.CPUSTATES]C.long{C.CP_USER, C.CP_NICE, C.CP_SYS, C.CP_INTR, C.CP_IDLE}
+
+	mib := [2]int32{C.CTL_KERN, C.KERN_CPTIME}
+	n := uintptr(0)
+	// First we determine how much memory we'll need to pass later on (via `n`)
+	_, _, errno := syscall.Syscall6(syscall.SYS___SYSCTL, uintptr(unsafe.Pointer(&mib[0])), 2, 0, uintptr(unsafe.Pointer(&n)), 0, 0)
+	if errno != 0 || n == 0 {
+		return nil
+	}
+
+	_, _, errno = syscall.Syscall6(syscall.SYS___SYSCTL, uintptr(unsafe.Pointer(&mib[0])), 2, uintptr(unsafe.Pointer(&load)), uintptr(unsafe.Pointer(&n)), 0, 0)
+	if errno != 0 || n == 0 {
+		return nil
+	}
+
+	self.User = uint64(load[0])
+	self.Nice = uint64(load[1])
+	self.Sys = uint64(load[2])
+	self.Irq = uint64(load[3])
+	self.Idle = uint64(load[4])
+
+	return nil
+}
+
+func (self *CpuList) Get() error {
+	return nil
+}
+
+func (self *ProcList) Get() error {
+	return nil
+}
+
+func (self *ProcArgs) Get(pid int) error {
+	return nil
+}
+
+func (self *ProcState) Get(pid int) error {
+	return nil
+}
+
+func (self *ProcMem) Get(pid int) error {
+	return nil
+}
+
+func (self *ProcTime) Get(pid int) error {
+	return nil
+}
+
+func (self *ProcExe) Get(pid int) error {
+	return nil
+}

--- a/sigar_unix.go
+++ b/sigar_unix.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2012 VMware, Inc.
 
-// +build darwin freebsd linux netbsd openbsd
+// +build darwin freebsd linux netbsd
 
 package gosigar
 


### PR DESCRIPTION
currently implemented are:
- FileSystemList
- Cpu
- Mem
- LoadAverage
- Uptime
- FileSystemUsage
- Swap

This is enough to bring basic topbeat functionality to OpenBSD:

```
{
  "@timestamp": "2016-04-04T12:51:08.016Z",
  "beat": {
    "hostname": "basalt.jasper.la",
    "name": "basalt.jasper.la"
  },
  "fs": {
    "avail": 3857862656,
    "device_name": "/dev/sd0a",
    "files": 545662,
    "free": 4069398528,
    "free_files": 542408,
    "mount_point": "/",
    "total": 4230739968,
    "used": 161341440,
    "used_p": 0.04
  },
  "type": "filesystem"
}
{
  "@timestamp": "2016-04-04T12:51:08.016Z",
  "beat": {
    "hostname": "basalt.jasper.la",
    "name": "basalt.jasper.la"
  },
  "fs": {
    "avail": 4682117120,
    "device_name": "/dev/sd0g",
    "files": 1065342,
    "free": 5104588800,
    "free_files": 789403,
    "mount_point": "/cvs",
    "total": 8449456128,
    "used": 3344867328,
    "used_p": 0.4
  },
  "type": "filesystem"
}
{
  "@timestamp": "2016-04-04T12:51:08.016Z",
  "beat": {
    "hostname": "basalt.jasper.la",
    "name": "basalt.jasper.la"
  },
  "cpu": {
    "idle": 6422348,
    "iowait": 0,
    "irq": 37951,
    "nice": 17720,
    "softirq": 0,
    "steal": 0,
    "system": 82196,
    "system_p": 0,
    "user": 51293,
    "user_p": 0
  },
  "load": {
    "load1": 2.60791015625,
    "load15": 2.61474609375,
    "load5": 2.7236328125
  },
  "mem": {
    "actual_free": 5403811840,
    "actual_used": 2605051904,
    "actual_used_p": 0.33,
    "free": 4799152128,
    "total": 8008863744,
    "used": 3209711616,
    "used_p": 0.4
  },
  "swap": {
    "free": 0,
    "total": 0,
    "used": 0,
    "used_p": 0
  },
  "type": "system"
}
```