### PR TITLE
Add table of implemented features by OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,24 @@ in pure go/cgo, rather than cgo bindings for libsigar.
 
 ## Supported platforms
 
-Currently targeting modern flavors of darwin and linux and windows.
+The features vary by operating system.
+
+| Feature         | Linux | Darwin | Windows | OpenBSD |
+|-----------------|:-----:|:------:|:-------:|:-------:|
+| Cpu             |   X   |    X   |    X    |    X    |
+| CpuList         |   X   |    X   |         |         |
+| FileSystemList  |   X   |    X   |    X    |    X    |
+| FileSystemUsage |   X   |    X   |    X    |    X    |
+| LoadAverage     |   X   |    X   |         |    X    |
+| Mem             |   X   |    X   |    X    |    X    |
+| ProcArgs        |   X   |    X   |    X    |         |
+| ProcExe         |   X   |    X   |         |         |
+| ProcList        |   X   |    X   |    X    |         |
+| ProcMem         |   X   |    X   |    X    |         |
+| ProcState       |   X   |    X   |    X    |         |
+| ProcTime        |   X   |    X   |    X    |         |
+| Swap            |   X   |    X   |         |    X    |
+| Uptime          |   X   |    X   |         |    X    |
 
 ## License
 


### PR DESCRIPTION
I added a table of the features implemented by OS. This includes the OpenBSD features that are currently in PR #22.