### PR TITLE
Added ability to return process group ID (pgid) for Darwin and Linux versions

### DIFF
--- a/sigar_darwin.go
+++ b/sigar_darwin.go
@@ -252,6 +252,8 @@ func (self *ProcState) Get(pid int) error {
 
 	self.Ppid = int(info.pbsd.pbi_ppid)
 
+	self.Pgid = int(info.pbsd.pbi_pgid)
+
 	self.Tty = int(info.pbsd.e_tdev)
 
 	self.Priority = int(info.ptinfo.pti_priority)

--- a/sigar_darwin_test.go
+++ b/sigar_darwin_test.go
@@ -1,0 +1,66 @@
+package gosigar_test
+
+import (
+	// "fmt"
+	"os/exec"
+	"strconv"
+	"testing"
+	"bytes"
+	"bufio"
+	"strings"
+
+	sigar "github.com/elastic/gosigar"
+	"github.com/stretchr/testify/assert"
+)
+
+var procinfo map[string]string
+
+func setUp(t testing.TB) {
+	out,err := exec.Command("/bin/ps","-p1", "-c","-opid,comm,stat,ppid,pgid,tty,pri,ni").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rdr := bufio.NewReader(bytes.NewReader(out))
+	_,err = rdr.ReadString('\n') // skip header
+	if err != nil {
+		t.Fatal(err)
+	}
+	data,err := rdr.ReadString('\n')
+	if err != nil {
+		t.Fatal(err)
+	}
+	procinfo = make(map[string]string,8)
+	fields := strings.Fields(data)
+	procinfo["pid"] = fields[0]
+	procinfo["name"] = fields[1]
+	procinfo["stat"] = fields[2]
+	procinfo["ppid"] = fields[3]
+	procinfo["pgid"] = fields[4]
+	procinfo["tty"] = fields[5]
+	procinfo["prio"] = fields[6]
+	procinfo["nice"] = fields[7]
+
+}
+
+func tearDown(t testing.TB) {
+}
+
+func TestDarwinProcState(t *testing.T) {
+	setUp(t)
+	defer tearDown(t)
+
+	state := sigar.ProcState{}
+	if assert.NoError(t, state.Get(1)) {
+
+		ppid,_ := strconv.Atoi(procinfo["ppid"])
+		pgid,_ := strconv.Atoi(procinfo["pgid"])
+
+		assert.Equal(t, procinfo["name"], state.Name)
+		assert.Equal(t, ppid, state.Ppid)
+		assert.Equal(t, pgid, state.Pgid)
+		assert.Equal(t, 1, state.Pgid)
+		assert.Equal(t, 0, state.Ppid)
+	}
+}
+
+

--- a/sigar_interface.go
+++ b/sigar_interface.go
@@ -109,6 +109,7 @@ type ProcState struct {
 	Username  string
 	State     RunState
 	Ppid      int
+	Pgid      int
 	Tty       int
 	Priority  int
 	Nice      int

--- a/sigar_linux.go
+++ b/sigar_linux.go
@@ -212,6 +212,8 @@ func (self *ProcState) Get(pid int) error {
 
 	self.Ppid, _ = strconv.Atoi(fields[1])
 
+	self.Pgid, _ = strconv.Atoi(fields[2])
+
 	self.Tty, _ = strconv.Atoi(fields[4])
 
 	self.Priority, _ = strconv.Atoi(fields[15])

--- a/sigar_linux_test.go
+++ b/sigar_linux_test.go
@@ -66,7 +66,8 @@ func TestLinuxProcState(t *testing.T) {
 
 			state := sigar.ProcState{}
 			if assert.NoError(t, state.Get(pid)) {
-				assert.Equal(t, n, state.Name)
+				assert.Equal(t, n, state.Name)				
+				assert.Equal(t, 2, state.Pgid)
 				assert.Equal(t, strconv.Itoa(uid), state.Username)
 			}
 		}()
@@ -218,9 +219,9 @@ DirectMap2M:      333824 kB
 }
 
 func writePidStats(pid int, procName string, path string) error {
-	stats := "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 " +
+	stats := "S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 " +
 		"20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 " +
-		"35 36 37 38 39 40"
+		"35 36 37 38 39"
 
 	statContents := []byte(fmt.Sprintf("%d (%s) %s", pid, procName, stats))
 	return ioutil.WriteFile(path, statContents, 0644)


### PR DESCRIPTION
Added ability to return process group ID (pgid) for Darwin and Linux versions, with the view to add this to Topbeat as well.