### PR TITLE
Added general file descriptor logic and implemented for linux

### DIFF
--- a/concrete_sigar.go
+++ b/concrete_sigar.go
@@ -67,3 +67,9 @@ func (c *ConcreteSigar) GetFileSystemUsage(path string) (FileSystemUsage, error)
 	err := f.Get(path)
 	return f, err
 }
+
+func (c *ConcreteSigar) GetFDUsage() (FDUsage, error) {
+	fd := FDUsage{}
+	err := fd.Get()
+	return fd, err
+}

--- a/concrete_sigar_test.go
+++ b/concrete_sigar_test.go
@@ -74,3 +74,16 @@ func TestConcreteFileSystemUsage(t *testing.T) {
 	fsusage, err = concreteSigar.GetFileSystemUsage("T O T A L L Y B O G U S")
 	assert.Error(t, err)
 }
+
+func TestConcreteGetFDUsage(t *testing.T) {
+	concreteSigar := &sigar.ConcreteSigar{}
+	fdUsage, err := concreteSigar.GetFDUsage()
+	// if it's not implemented, don't test
+	if _, ok := err.(*sigar.ErrNotImplemented); ok {
+		t.Skipf("Skipping *ConcreteSigar.GetFDUsage test because it is not implemented for " + runtime.GOOS)
+	}
+	if assert.NoError(t, err) {
+		assert.True(t, fdUsage.Open > 0)
+		assert.True(t, fdUsage.Open <= fdUsage.Max)
+	}
+}

--- a/sigar_darwin.go
+++ b/sigar_darwin.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"os/user"
+	"runtime"
 	"strconv"
 	"syscall"
 	"time"
@@ -162,6 +163,10 @@ func (self *CpuList) Get() error {
 	}
 
 	return nil
+}
+
+func (self *FDUsage) Get() error {
+	return &ErrNotImplemented{runtime.GOOS}
 }
 
 func (self *FileSystemList) Get() error {
@@ -327,6 +332,10 @@ func (self *ProcExe) Get(pid int) error {
 	}
 
 	return kern_procargs(pid, exe, nil, nil)
+}
+
+func (self *ProcFDUsage) Get(pid int) error {
+	return &ErrNotImplemented{runtime.GOOS}
 }
 
 // wrapper around sysctl KERN_PROCARGS2

--- a/sigar_interface.go
+++ b/sigar_interface.go
@@ -10,6 +10,15 @@ type Sigar interface {
 	GetMem() (Mem, error)
 	GetSwap() (Swap, error)
 	GetFileSystemUsage(string) (FileSystemUsage, error)
+	GetFDUsage() (FDUsage, error)
+}
+
+type ErrNotImplemented struct {
+	OS string
+}
+
+func (e ErrNotImplemented) Error() string {
+	return "not implemented on " + e.OS
 }
 
 type Cpu struct {
@@ -65,6 +74,12 @@ type Swap struct {
 
 type CpuList struct {
 	List []Cpu
+}
+
+type FDUsage struct {
+	Open   uint64
+	Unused uint64
+	Max    uint64
 }
 
 type FileSystem struct {
@@ -140,4 +155,10 @@ type ProcExe struct {
 	Name string
 	Cwd  string
 	Root string
+}
+
+type ProcFDUsage struct {
+	Open      uint64
+	SoftLimit uint64
+	HardLimit uint64
 }

--- a/sigar_openbsd.go
+++ b/sigar_openbsd.go
@@ -19,6 +19,7 @@ import "C"
 //import "github.com/davecgh/go-spew/spew"
 
 import (
+	"runtime"
 	"syscall"
 	"time"
 	"unsafe"
@@ -185,6 +186,10 @@ func (self *FileSystemUsage) Get(path string) error {
 	self.FreeFiles = stat.F_ffree
 
 	return nil
+}
+
+func (self *FDUsage) Get() error {
+	return &ErrNotImplemented{runtime.GOOS}
 }
 
 func (self *LoadAverage) Get() error {
@@ -366,6 +371,10 @@ func (self *ProcTime) Get(pid int) error {
 
 func (self *ProcExe) Get(pid int) error {
 	return nil
+}
+
+func (self *ProcFDUsage) Get(pid int) error {
+	return &ErrNotImplemented{runtime.GOOS}
 }
 
 func fillCpu(cpu *Cpu, load [C.CPUSTATES]C.long) {

--- a/sigar_windows.go
+++ b/sigar_windows.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"syscall"
 	"time"
 	"unsafe"
@@ -207,6 +208,10 @@ func (self *FileSystemList) Get() error {
 		self.List = append(self.List, d)
 	}
 	return nil
+}
+
+func (self *FDUsage) Get() error {
+	return &ErrNotImplemented{runtime.GOOS}
 }
 
 // Retrieves the process identifier for each process object in the system.
@@ -464,6 +469,10 @@ func (self *ProcArgs) Get(pid int) error {
 
 func (self *ProcExe) Get(pid int) error {
 	return notImplemented()
+}
+
+func (self *ProcFDUsage) Get(pid int) error {
+	return &ErrNotImplemented{runtime.GOOS}
 }
 
 func (self *FileSystemUsage) Get(path string) error {


### PR DESCRIPTION
Add support for #29.

I have implemented the initial logic for Linux and just wanted to get some input to make sure I'm on the right track before I move on to attempting some of the other OSes.  A few things of note / questions:

1. Also, I'm not sure what to do what to do when reading `/proc/{PID}/fd` fails which is will for root processes if run as not root.  Currently, it just returns 0 for the open count.  I think this maybe the best route, but I am not sure.
2. I assume I should also add tests for the new logic?
3. Since we don't want the FD metrics reported by the beat if it's not implemented for the OS, I think instead of returning nil I should through an error in the unimplemented functions?