### PR TITLE
Add support for FreeBSD.

### DIFF
--- a/sigar_freebsd.go
+++ b/sigar_freebsd.go
@@ -1,0 +1,133 @@
+// Copied and modified from sigar_linux.go.
+
+package gosigar
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"io/ioutil"
+	"strconv"
+	"strings"
+	"unsafe"
+)
+
+/*
+#include <sys/param.h>
+#include <sys/mount.h>
+#include <sys/ucred.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <time.h>
+*/
+import "C"
+
+func init() {
+	system.ticks = uint64(C.sysconf(C._SC_CLK_TCK))
+
+	Procd = "/compat/linux/proc"
+
+	getLinuxBootTime()
+}
+
+func getMountTableFileName() string {
+	return Procd + "/mtab"
+}
+
+func (self *Uptime) Get() error {
+	ts := C.struct_timespec{}
+
+	if _, err := C.clock_gettime(C.CLOCK_UPTIME, &ts); err != nil {
+		return err
+	}
+
+	self.Length = float64(ts.tv_sec) + 1e-9*float64(ts.tv_nsec)
+
+	return nil
+}
+
+func (self *FDUsage) Get() error {
+	val := C.uint32_t(0)
+	sc := C.size_t(4)
+
+	name := C.CString("kern.openfiles")
+	_, err := C.sysctlbyname(name, unsafe.Pointer(&val), &sc, nil, 0)
+	C.free(unsafe.Pointer(name))
+	if err != nil {
+		return err
+	}
+	self.Open = uint64(val)
+
+	name = C.CString("kern.maxfiles")
+	_, err = C.sysctlbyname(name, unsafe.Pointer(&val), &sc, nil, 0)
+	C.free(unsafe.Pointer(name))
+	if err != nil {
+		return err
+	}
+	self.Max = uint64(val)
+
+	self.Unused = self.Max - self.Open
+
+	return nil
+}
+
+func (self *ProcFDUsage) Get(pid int) error {
+	err := readFile(procFileNameNative(pid, "rlimit"), func(line string) bool {
+		if strings.HasPrefix(line, "nofile ") {
+			fields := strings.Fields(line)
+			if len(fields) == 3 {
+				self.SoftLimit, _ = strconv.ParseUint(fields[1], 10, 64)
+				self.HardLimit, _ = strconv.ParseUint(fields[2], 10, 64)
+			}
+			return false
+		}
+		return true
+	})
+	if err != nil {
+		return err
+	}
+	fds, err := ioutil.ReadDir(procFileName(pid, "fd"))
+	if err != nil {
+		return err
+	}
+	self.Open = uint64(len(fds))
+	return nil
+}
+
+func parseCpuStat(self *Cpu, line string) error {
+	fields := strings.Fields(line)
+
+	self.User, _ = strtoull(fields[1])
+	self.Nice, _ = strtoull(fields[2])
+	self.Sys, _ = strtoull(fields[3])
+	self.Idle, _ = strtoull(fields[4])
+	return nil
+}
+
+func readFile(file string, handler func(string) bool) error {
+	contents, err := ioutil.ReadFile(file)
+	if err != nil {
+		return err
+	}
+
+	reader := bufio.NewReader(bytes.NewBuffer(contents))
+
+	for {
+		line, _, err := reader.ReadLine()
+		if err == io.EOF {
+			break
+		}
+		if !handler(string(line)) {
+			break
+		}
+	}
+
+	return nil
+}
+
+func procFileNameNative(pid int, name string) string {
+	return "/proc/" + strconv.Itoa(pid) + "/" + name
+}

--- a/sigar_linux.go
+++ b/sigar_linux.go
@@ -3,55 +3,22 @@
 package gosigar
 
 import (
-	"bufio"
-	"bytes"
-	"errors"
-	"fmt"
-	"io"
 	"io/ioutil"
-	"os"
-	"os/user"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
 )
-
-var system struct {
-	ticks uint64
-	btime uint64
-}
-
-var Procd string
 
 func init() {
 	system.ticks = 100 // C.sysconf(C._SC_CLK_TCK)
 
 	Procd = "/proc"
 
-	// grab system boot time
-	readFile(Procd+"/stat", func(line string) bool {
-		if strings.HasPrefix(line, "btime") {
-			system.btime, _ = strtoull(line[6:])
-			return false // stop reading
-		}
-		return true
-	})
+	getLinuxBootTime()
 }
 
-func (self *LoadAverage) Get() error {
-	line, err := ioutil.ReadFile(Procd + "/loadavg")
-	if err != nil {
-		return nil
-	}
-
-	fields := strings.Fields(string(line))
-
-	self.One, _ = strconv.ParseFloat(fields[0], 64)
-	self.Five, _ = strconv.ParseFloat(fields[1], 64)
-	self.Fifteen, _ = strconv.ParseFloat(fields[2], 64)
-
-	return nil
+func getMountTableFileName() string {
+	return "/etc/mtab"
 }
 
 func (self *Uptime) Get() error {
@@ -66,99 +33,6 @@ func (self *Uptime) Get() error {
 	return nil
 }
 
-func (self *Mem) Get() error {
-	var buffers, cached uint64
-	table := map[string]*uint64{
-		"MemTotal": &self.Total,
-		"MemFree":  &self.Free,
-		"Buffers":  &buffers,
-		"Cached":   &cached,
-	}
-
-	if err := parseMeminfo(table); err != nil {
-		return err
-	}
-
-	self.Used = self.Total - self.Free
-	kern := buffers + cached
-	self.ActualFree = self.Free + kern
-	self.ActualUsed = self.Used - kern
-
-	return nil
-}
-
-func (self *Swap) Get() error {
-	table := map[string]*uint64{
-		"SwapTotal": &self.Total,
-		"SwapFree":  &self.Free,
-	}
-
-	if err := parseMeminfo(table); err != nil {
-		return err
-	}
-
-	self.Used = self.Total - self.Free
-	return nil
-}
-
-func (self *Cpu) Get() error {
-	return readFile(Procd+"/stat", func(line string) bool {
-		if len(line) > 4 && line[0:4] == "cpu " {
-			parseCpuStat(self, line)
-			return false
-		}
-		return true
-
-	})
-}
-
-func (self *CpuList) Get() error {
-	capacity := len(self.List)
-	if capacity == 0 {
-		capacity = 4
-	}
-	list := make([]Cpu, 0, capacity)
-
-	err := readFile(Procd+"/stat", func(line string) bool {
-		if len(line) > 3 && line[0:3] == "cpu" && line[3] != ' ' {
-			cpu := Cpu{}
-			parseCpuStat(&cpu, line)
-			list = append(list, cpu)
-		}
-		return true
-	})
-
-	self.List = list
-
-	return err
-}
-
-func (self *FileSystemList) Get() error {
-	capacity := len(self.List)
-	if capacity == 0 {
-		capacity = 10
-	}
-	fslist := make([]FileSystem, 0, capacity)
-
-	err := readFile("/etc/mtab", func(line string) bool {
-		fields := strings.Fields(line)
-
-		fs := FileSystem{}
-		fs.DevName = fields[0]
-		fs.DirName = fields[1]
-		fs.SysTypeName = fields[2]
-		fs.Options = fields[3]
-
-		fslist = append(fslist, fs)
-
-		return true
-	})
-
-	self.List = fslist
-
-	return err
-}
-
 func (self *FDUsage) Get() error {
 	return readFile(Procd+"/sys/fs/file-nr", func(line string) bool {
 		fields := strings.Fields(line)
@@ -169,186 +43,6 @@ func (self *FDUsage) Get() error {
 		}
 		return false
 	})
-}
-
-func (self *ProcList) Get() error {
-	dir, err := os.Open(Procd)
-	if err != nil {
-		return err
-	}
-	defer dir.Close()
-
-	const readAllDirnames = -1 // see os.File.Readdirnames doc
-
-	names, err := dir.Readdirnames(readAllDirnames)
-	if err != nil {
-		return err
-	}
-
-	capacity := len(names)
-	list := make([]int, 0, capacity)
-
-	for _, name := range names {
-		if name[0] < '0' || name[0] > '9' {
-			continue
-		}
-		pid, err := strconv.Atoi(name)
-		if err == nil {
-			list = append(list, pid)
-		}
-	}
-
-	self.List = list
-
-	return nil
-}
-
-func (self *ProcState) Get(pid int) error {
-	contents, err := readProcFile(pid, "stat")
-	if err != nil {
-		return err
-	}
-
-	headerAndStats := strings.SplitAfterN(string(contents), ")", 2)
-	pidAndName := headerAndStats[0]
-	fields := strings.Fields(headerAndStats[1])
-
-	name := strings.SplitAfterN(pidAndName, " ", 2)[1]
-	if name[0] == '(' && name[len(name)-1] == ')' {
-		self.Name = name[1 : len(name)-1] // strip ()'s
-	} else {
-		return errors.New(fmt.Sprintf("Malformed process stats for pid %d", pid))
-	}
-
-	self.State = RunState(fields[0][0])
-
-	self.Ppid, _ = strconv.Atoi(fields[1])
-
-	self.Pgid, _ = strconv.Atoi(fields[2])
-
-	self.Tty, _ = strconv.Atoi(fields[4])
-
-	self.Priority, _ = strconv.Atoi(fields[15])
-
-	self.Nice, _ = strconv.Atoi(fields[16])
-
-	self.Processor, _ = strconv.Atoi(fields[36])
-
-	// Read /proc/[pid]/status to get the uid, then lookup uid to get username.
-	status, err := getProcStatus(pid)
-	if err != nil {
-		return fmt.Errorf("failed to read process status for pid %d. %v", pid, err)
-	}
-	uids, err := getUIDs(status)
-	if err != nil {
-		return fmt.Errorf("failed to read process status for pid %d. %v", pid, err)
-	}
-	user, err := user.LookupId(uids[0])
-	if err == nil {
-		self.Username = user.Username
-	} else {
-		self.Username = uids[0]
-	}
-
-	return nil
-}
-
-func (self *ProcMem) Get(pid int) error {
-	contents, err := readProcFile(pid, "statm")
-	if err != nil {
-		return err
-	}
-
-	fields := strings.Fields(string(contents))
-
-	size, _ := strtoull(fields[0])
-	self.Size = size << 12
-
-	rss, _ := strtoull(fields[1])
-	self.Resident = rss << 12
-
-	share, _ := strtoull(fields[2])
-	self.Share = share << 12
-
-	contents, err = readProcFile(pid, "stat")
-	if err != nil {
-		return err
-	}
-
-	fields = strings.Fields(string(contents))
-
-	self.MinorFaults, _ = strtoull(fields[10])
-	self.MajorFaults, _ = strtoull(fields[12])
-	self.PageFaults = self.MinorFaults + self.MajorFaults
-
-	return nil
-}
-
-func (self *ProcTime) Get(pid int) error {
-	contents, err := readProcFile(pid, "stat")
-	if err != nil {
-		return err
-	}
-
-	fields := strings.Fields(string(contents))
-
-	user, _ := strtoull(fields[13])
-	sys, _ := strtoull(fields[14])
-	// convert to millis
-	self.User = user * (1000 / system.ticks)
-	self.Sys = sys * (1000 / system.ticks)
-	self.Total = self.User + self.Sys
-
-	// convert to millis
-	self.StartTime, _ = strtoull(fields[21])
-	self.StartTime /= system.ticks
-	self.StartTime += system.btime
-	self.StartTime *= 1000
-
-	return nil
-}
-
-func (self *ProcArgs) Get(pid int) error {
-	contents, err := readProcFile(pid, "cmdline")
-	if err != nil {
-		return err
-	}
-
-	bbuf := bytes.NewBuffer(contents)
-
-	var args []string
-
-	for {
-		arg, err := bbuf.ReadBytes(0)
-		if err == io.EOF {
-			break
-		}
-		args = append(args, string(chop(arg)))
-	}
-
-	self.List = args
-
-	return nil
-}
-
-func (self *ProcExe) Get(pid int) error {
-	fields := map[string]*string{
-		"exe":  &self.Name,
-		"cwd":  &self.Cwd,
-		"root": &self.Root,
-	}
-
-	for name, field := range fields {
-		val, err := os.Readlink(procFileName(pid, name))
-
-		if err != nil {
-			return err
-		}
-
-		*field = val
-	}
-
-	return nil
 }
 
 func (self *ProcFDUsage) Get(pid int) error {
@@ -374,22 +68,6 @@ func (self *ProcFDUsage) Get(pid int) error {
 	return nil
 }
 
-func parseMeminfo(table map[string]*uint64) error {
-	return readFile(Procd+"/meminfo", func(line string) bool {
-		fields := strings.Split(line, ":")
-
-		if ptr := table[fields[0]]; ptr != nil {
-			num := strings.TrimLeft(fields[1], " ")
-			val, err := strtoull(strings.Fields(num)[0])
-			if err == nil {
-				*ptr = val * 1024
-			}
-		}
-
-		return true
-	})
-}
-
 func parseCpuStat(self *Cpu, line string) error {
 	fields := strings.Fields(line)
 
@@ -403,80 +81,4 @@ func parseCpuStat(self *Cpu, line string) error {
 	self.Stolen, _ = strtoull(fields[8])
 
 	return nil
-}
-
-func readFile(file string, handler func(string) bool) error {
-	contents, err := ioutil.ReadFile(file)
-	if err != nil {
-		return err
-	}
-
-	reader := bufio.NewReader(bytes.NewBuffer(contents))
-
-	for {
-		line, _, err := reader.ReadLine()
-		if err == io.EOF {
-			break
-		}
-		if !handler(string(line)) {
-			break
-		}
-	}
-
-	return nil
-}
-
-func strtoull(val string) (uint64, error) {
-	return strconv.ParseUint(val, 10, 64)
-}
-
-func procFileName(pid int, name string) string {
-	return Procd + "/" + strconv.Itoa(pid) + "/" + name
-}
-
-func readProcFile(pid int, name string) ([]byte, error) {
-	path := procFileName(pid, name)
-	contents, err := ioutil.ReadFile(path)
-
-	if err != nil {
-		if perr, ok := err.(*os.PathError); ok {
-			if perr.Err == syscall.ENOENT {
-				return nil, syscall.ESRCH
-			}
-		}
-	}
-
-	return contents, err
-}
-
-// getProcStatus reads /proc/[pid]/status which contains process status
-// information in human readable form.
-func getProcStatus(pid int) (map[string]string, error) {
-	status := make(map[string]string, 42)
-	path := filepath.Join(Procd, strconv.Itoa(pid), "status")
-	err := readFile(path, func(line string) bool {
-		fields := strings.SplitN(line, ":", 2)
-		if len(fields) == 2 {
-			status[fields[0]] = strings.TrimSpace(fields[1])
-		}
-
-		return true
-	})
-	return status, err
-}
-
-// getUIDs reads the "Uid" value from status and splits it into four values --
-// real, effective, saved set, and  file system UIDs.
-func getUIDs(status map[string]string) ([]string, error) {
-	uidLine, ok := status["Uid"]
-	if !ok {
-		return nil, fmt.Errorf("Uid not found in proc status")
-	}
-
-	uidStrs := strings.Fields(uidLine)
-	if len(uidStrs) != 4 {
-		return nil, fmt.Errorf("Uid line ('%s') did not contain four values", uidLine)
-	}
-
-	return uidStrs, nil
 }

--- a/sigar_linux_common.go
+++ b/sigar_linux_common.go
@@ -1,0 +1,418 @@
+// Copyright (c) 2012 VMware, Inc.
+
+// +build freebsd linux
+
+package gosigar
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+var system struct {
+	ticks uint64
+	btime uint64
+}
+
+var Procd string
+
+func getLinuxBootTime() {
+	// grab system boot time
+	readFile(Procd+"/stat", func(line string) bool {
+		if strings.HasPrefix(line, "btime") {
+			system.btime, _ = strtoull(line[6:])
+			return false // stop reading
+		}
+		return true
+	})
+}
+
+func (self *LoadAverage) Get() error {
+	line, err := ioutil.ReadFile(Procd + "/loadavg")
+	if err != nil {
+		return nil
+	}
+
+	fields := strings.Fields(string(line))
+
+	self.One, _ = strconv.ParseFloat(fields[0], 64)
+	self.Five, _ = strconv.ParseFloat(fields[1], 64)
+	self.Fifteen, _ = strconv.ParseFloat(fields[2], 64)
+
+	return nil
+}
+
+func (self *Mem) Get() error {
+	var buffers, cached uint64
+	table := map[string]*uint64{
+		"MemTotal": &self.Total,
+		"MemFree":  &self.Free,
+		"Buffers":  &buffers,
+		"Cached":   &cached,
+	}
+
+	if err := parseMeminfo(table); err != nil {
+		return err
+	}
+
+	self.Used = self.Total - self.Free
+	kern := buffers + cached
+	self.ActualFree = self.Free + kern
+	self.ActualUsed = self.Used - kern
+
+	return nil
+}
+
+func (self *Swap) Get() error {
+	table := map[string]*uint64{
+		"SwapTotal": &self.Total,
+		"SwapFree":  &self.Free,
+	}
+
+	if err := parseMeminfo(table); err != nil {
+		return err
+	}
+
+	self.Used = self.Total - self.Free
+	return nil
+}
+
+func (self *Cpu) Get() error {
+	return readFile(Procd+"/stat", func(line string) bool {
+		if len(line) > 4 && line[0:4] == "cpu " {
+			parseCpuStat(self, line)
+			return false
+		}
+		return true
+
+	})
+}
+
+func (self *CpuList) Get() error {
+	capacity := len(self.List)
+	if capacity == 0 {
+		capacity = 4
+	}
+	list := make([]Cpu, 0, capacity)
+
+	err := readFile(Procd+"/stat", func(line string) bool {
+		if len(line) > 3 && line[0:3] == "cpu" && line[3] != ' ' {
+			cpu := Cpu{}
+			parseCpuStat(&cpu, line)
+			list = append(list, cpu)
+		}
+		return true
+	})
+
+	self.List = list
+
+	return err
+}
+
+func (self *FileSystemList) Get() error {
+	capacity := len(self.List)
+	if capacity == 0 {
+		capacity = 10
+	}
+	fslist := make([]FileSystem, 0, capacity)
+
+	err := readFile(getMountTableFileName(), func(line string) bool {
+		fields := strings.Fields(line)
+
+		fs := FileSystem{}
+		fs.DevName = fields[0]
+		fs.DirName = fields[1]
+		fs.SysTypeName = fields[2]
+		fs.Options = fields[3]
+
+		fslist = append(fslist, fs)
+
+		return true
+	})
+
+	self.List = fslist
+
+	return err
+}
+
+func (self *ProcList) Get() error {
+	dir, err := os.Open(Procd)
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+
+	const readAllDirnames = -1 // see os.File.Readdirnames doc
+
+	names, err := dir.Readdirnames(readAllDirnames)
+	if err != nil {
+		return err
+	}
+
+	capacity := len(names)
+	list := make([]int, 0, capacity)
+
+	for _, name := range names {
+		if name[0] < '0' || name[0] > '9' {
+			continue
+		}
+		pid, err := strconv.Atoi(name)
+		if err == nil {
+			list = append(list, pid)
+		}
+	}
+
+	self.List = list
+
+	return nil
+}
+
+func (self *ProcState) Get(pid int) error {
+	contents, err := readProcFile(pid, "stat")
+	if err != nil {
+		return err
+	}
+
+	headerAndStats := strings.SplitAfterN(string(contents), ")", 2)
+	pidAndName := headerAndStats[0]
+	fields := strings.Fields(headerAndStats[1])
+
+	name := strings.SplitAfterN(pidAndName, " ", 2)[1]
+	if name[0] == '(' && name[len(name)-1] == ')' {
+		self.Name = name[1 : len(name)-1] // strip ()'s
+	} else {
+		return errors.New(fmt.Sprintf("Malformed process stats for pid %d", pid))
+	}
+
+	self.State = RunState(fields[0][0])
+
+	self.Ppid, _ = strconv.Atoi(fields[1])
+
+	self.Pgid, _ = strconv.Atoi(fields[2])
+
+	self.Tty, _ = strconv.Atoi(fields[4])
+
+	self.Priority, _ = strconv.Atoi(fields[15])
+
+	self.Nice, _ = strconv.Atoi(fields[16])
+
+	self.Processor, _ = strconv.Atoi(fields[36])
+
+	// Read /proc/[pid]/status to get the uid, then lookup uid to get username.
+	status, err := getProcStatus(pid)
+	if err != nil {
+		return fmt.Errorf("failed to read process status for pid %d. %v", pid, err)
+	}
+	uids, err := getUIDs(status)
+	if err != nil {
+		return fmt.Errorf("failed to read process status for pid %d. %v", pid, err)
+	}
+	user, err := user.LookupId(uids[0])
+	if err == nil {
+		self.Username = user.Username
+	} else {
+		self.Username = uids[0]
+	}
+
+	return nil
+}
+
+func (self *ProcMem) Get(pid int) error {
+	contents, err := readProcFile(pid, "statm")
+	if err != nil {
+		return err
+	}
+
+	fields := strings.Fields(string(contents))
+
+	size, _ := strtoull(fields[0])
+	self.Size = size << 12
+
+	rss, _ := strtoull(fields[1])
+	self.Resident = rss << 12
+
+	share, _ := strtoull(fields[2])
+	self.Share = share << 12
+
+	contents, err = readProcFile(pid, "stat")
+	if err != nil {
+		return err
+	}
+
+	fields = strings.Fields(string(contents))
+
+	self.MinorFaults, _ = strtoull(fields[10])
+	self.MajorFaults, _ = strtoull(fields[12])
+	self.PageFaults = self.MinorFaults + self.MajorFaults
+
+	return nil
+}
+
+func (self *ProcTime) Get(pid int) error {
+	contents, err := readProcFile(pid, "stat")
+	if err != nil {
+		return err
+	}
+
+	fields := strings.Fields(string(contents))
+
+	user, _ := strtoull(fields[13])
+	sys, _ := strtoull(fields[14])
+	// convert to millis
+	self.User = user * (1000 / system.ticks)
+	self.Sys = sys * (1000 / system.ticks)
+	self.Total = self.User + self.Sys
+
+	// convert to millis
+	self.StartTime, _ = strtoull(fields[21])
+	self.StartTime /= system.ticks
+	self.StartTime += system.btime
+	self.StartTime *= 1000
+
+	return nil
+}
+
+func (self *ProcArgs) Get(pid int) error {
+	contents, err := readProcFile(pid, "cmdline")
+	if err != nil {
+		return err
+	}
+
+	bbuf := bytes.NewBuffer(contents)
+
+	var args []string
+
+	for {
+		arg, err := bbuf.ReadBytes(0)
+		if err == io.EOF {
+			break
+		}
+		args = append(args, string(chop(arg)))
+	}
+
+	self.List = args
+
+	return nil
+}
+
+func (self *ProcExe) Get(pid int) error {
+	fields := map[string]*string{
+		"exe":  &self.Name,
+		"cwd":  &self.Cwd,
+		"root": &self.Root,
+	}
+
+	for name, field := range fields {
+		val, err := os.Readlink(procFileName(pid, name))
+
+		if err != nil {
+			return err
+		}
+
+		*field = val
+	}
+
+	return nil
+}
+
+func parseMeminfo(table map[string]*uint64) error {
+	return readFile(Procd+"/meminfo", func(line string) bool {
+		fields := strings.Split(line, ":")
+
+		if ptr := table[fields[0]]; ptr != nil {
+			num := strings.TrimLeft(fields[1], " ")
+			val, err := strtoull(strings.Fields(num)[0])
+			if err == nil {
+				*ptr = val * 1024
+			}
+		}
+
+		return true
+	})
+}
+
+func readFile(file string, handler func(string) bool) error {
+	contents, err := ioutil.ReadFile(file)
+	if err != nil {
+		return err
+	}
+
+	reader := bufio.NewReader(bytes.NewBuffer(contents))
+
+	for {
+		line, _, err := reader.ReadLine()
+		if err == io.EOF {
+			break
+		}
+		if !handler(string(line)) {
+			break
+		}
+	}
+
+	return nil
+}
+
+func strtoull(val string) (uint64, error) {
+	return strconv.ParseUint(val, 10, 64)
+}
+
+func procFileName(pid int, name string) string {
+	return Procd + "/" + strconv.Itoa(pid) + "/" + name
+}
+
+func readProcFile(pid int, name string) ([]byte, error) {
+	path := procFileName(pid, name)
+	contents, err := ioutil.ReadFile(path)
+
+	if err != nil {
+		if perr, ok := err.(*os.PathError); ok {
+			if perr.Err == syscall.ENOENT {
+				return nil, syscall.ESRCH
+			}
+		}
+	}
+
+	return contents, err
+}
+
+// getProcStatus reads /proc/[pid]/status which contains process status
+// information in human readable form.
+func getProcStatus(pid int) (map[string]string, error) {
+	status := make(map[string]string, 42)
+	path := filepath.Join(Procd, strconv.Itoa(pid), "status")
+	err := readFile(path, func(line string) bool {
+		fields := strings.SplitN(line, ":", 2)
+		if len(fields) == 2 {
+			status[fields[0]] = strings.TrimSpace(fields[1])
+		}
+
+		return true
+	})
+	return status, err
+}
+
+// getUIDs reads the "Uid" value from status and splits it into four values --
+// real, effective, saved set, and  file system UIDs.
+func getUIDs(status map[string]string) ([]string, error) {
+	uidLine, ok := status["Uid"]
+	if !ok {
+		return nil, fmt.Errorf("Uid not found in proc status")
+	}
+
+	uidStrs := strings.Fields(uidLine)
+	if len(uidStrs) != 4 {
+		return nil, fmt.Errorf("Uid line ('%s') did not contain four values", uidLine)
+	}
+
+	return uidStrs, nil
+}

--- a/sigar_unix.go
+++ b/sigar_unix.go
@@ -18,7 +18,7 @@ func (self *FileSystemUsage) Get(path string) error {
 	self.Avail = uint64(stat.Bavail) * uint64(stat.Bsize)
 	self.Used = self.Total - self.Free
 	self.Files = stat.Files
-	self.FreeFiles = stat.Ffree
+	self.FreeFiles = uint64(stat.Ffree)
 
 	return nil
 }


### PR DESCRIPTION
This implementation requires to mount the Linux compatibility /proc
filesystem in /compat/linux/proc. Check the FreeBSD handbook for
details.