### PR TITLE
Enhancement/refactoring for the cgroup package

### DIFF
--- a/cgroup/blkio.go
+++ b/cgroup/blkio.go
@@ -15,7 +15,7 @@ import (
 //
 // https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt
 type BlockIOSubsystem struct {
-	SubsystemInfo
+	Metadata
 	Throttle ThrottlePolicy `json:"throttle,omitempty"` // Throttle limits for upper IO rates and metrics.
 	//CFQ      CFQScheduler   `json:"cfq,omitempty"`      // Completely fair queue scheduler limits and metrics.
 }
@@ -90,11 +90,9 @@ type blkioValue struct {
 	Value     uint64
 }
 
-// Get reads metrics from the "blkio" subsystem. path is the filepath to the
+// get reads metrics from the "blkio" subsystem. path is the filepath to the
 // cgroup hierarchy to read.
-func (blkio *BlockIOSubsystem) Get(path string) error {
-	blkio.Path = path
-
+func (blkio *BlockIOSubsystem) get(path string) error {
 	if err := blkioThrottle(path, blkio); err != nil {
 		return err
 	}

--- a/cgroup/blkio_test.go
+++ b/cgroup/blkio_test.go
@@ -68,17 +68,16 @@ func TestBlkioThrottle(t *testing.T) {
 
 func TestBlockIOSubsystemGet(t *testing.T) {
 	blkio := BlockIOSubsystem{}
-	if err := blkio.Get(blkioPath); err != nil {
+	if err := blkio.get(blkioPath); err != nil {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, blkioPath, blkio.Path)
 	assert.True(t, len(blkio.Throttle.Devices) > 0)
 }
 
 func TestBlockIOSubsystemJSON(t *testing.T) {
 	blkio := BlockIOSubsystem{}
-	if err := blkio.Get(blkioPath); err != nil {
+	if err := blkio.get(blkioPath); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cgroup/cpu.go
+++ b/cgroup/cpu.go
@@ -11,7 +11,7 @@ import (
 // when the system is busy. This subsystem does not track CPU usage, for that
 // information see the "cpuacct" subsystem.
 type CPUSubsystem struct {
-	SubsystemInfo
+	Metadata
 	// Completely Fair Scheduler (CFS) settings.
 	CFS CFS `json:"cfs,omitempty"`
 	// Real-time (RT) Scheduler settings.
@@ -54,11 +54,9 @@ type ThrottleStats struct {
 	ThrottledTimeNanos uint64 `json:"throttled_nanos,omitempty"`
 }
 
-// Get reads metrics from the "cpu" subsystem. path is the filepath to the
+// get reads metrics from the "cpu" subsystem. path is the filepath to the
 // cgroup hierarchy to read.
-func (cpu *CPUSubsystem) Get(path string) error {
-	cpu.Path = path
-
+func (cpu *CPUSubsystem) get(path string) error {
 	if err := cpuCFS(path, cpu); err != nil {
 		return err
 	}

--- a/cgroup/cpu_test.go
+++ b/cgroup/cpu_test.go
@@ -43,11 +43,10 @@ func TestCpuRT(t *testing.T) {
 
 func TestCpuSubsystemGet(t *testing.T) {
 	cpu := CPUSubsystem{}
-	if err := cpu.Get(cpuPath); err != nil {
+	if err := cpu.get(cpuPath); err != nil {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, cpuPath, cpu.Path)
 	assert.Equal(t, uint64(769021), cpu.Stats.Periods)
 	assert.Equal(t, uint64(100000), cpu.CFS.PeriodMicros)
 	assert.Equal(t, uint64(1000000), cpu.RT.PeriodMicros)
@@ -55,7 +54,7 @@ func TestCpuSubsystemGet(t *testing.T) {
 
 func TestCpuSubsystemJSON(t *testing.T) {
 	cpu := CPUSubsystem{}
-	if err := cpu.Get(cpuPath); err != nil {
+	if err := cpu.get(cpuPath); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cgroup/cpuacct.go
+++ b/cgroup/cpuacct.go
@@ -15,7 +15,7 @@ var clockTicks = uint64(util.GetClockTicks())
 
 // CPUAccountingSubsystem contains metrics from the "cpuacct" subsystem.
 type CPUAccountingSubsystem struct {
-	SubsystemInfo
+	Metadata
 	TotalNanos  uint64   `json:"total_nanos"`
 	UsagePerCPU []uint64 `json:"usage_percpu_nanos"`
 	// CPU time statistics for tasks in this cgroup.
@@ -28,11 +28,9 @@ type CPUAccountingStats struct {
 	SystemNanos uint64 `json:"system_nanos"`
 }
 
-// Get reads metrics from the "cpuacct" subsystem. path is the filepath to the
+// get reads metrics from the "cpuacct" subsystem. path is the filepath to the
 // cgroup hierarchy to read.
-func (cpuacct *CPUAccountingSubsystem) Get(path string) error {
-	cpuacct.Path = path
-
+func (cpuacct *CPUAccountingSubsystem) get(path string) error {
 	if err := cpuacctStat(path, cpuacct); err != nil {
 		return err
 	}

--- a/cgroup/cpuacct_test.go
+++ b/cgroup/cpuacct_test.go
@@ -39,11 +39,10 @@ func TestCpuacctUsagePerCPU(t *testing.T) {
 
 func TestCPUAccountingSubsystem_Get(t *testing.T) {
 	cpuacct := CPUAccountingSubsystem{}
-	if err := cpuacct.Get(cpuacctPath); err != nil {
+	if err := cpuacct.get(cpuacctPath); err != nil {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, cpuacctPath, cpuacct.Path)
 	assert.Equal(t, uint64(61950000000), cpuacct.Stats.UserNanos)
 	assert.Equal(t, uint64(95996653175), cpuacct.TotalNanos)
 	assert.Len(t, cpuacct.UsagePerCPU, 4)
@@ -51,7 +50,7 @@ func TestCPUAccountingSubsystem_Get(t *testing.T) {
 
 func TestCPUAccountingSubsystemJSON(t *testing.T) {
 	cpuacct := CPUAccountingSubsystem{}
-	if err := cpuacct.Get(cpuacctPath); err != nil {
+	if err := cpuacct.get(cpuacctPath); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cgroup/memory.go
+++ b/cgroup/memory.go
@@ -8,7 +8,7 @@ import (
 
 // MemorySubsystem contains the metrics and limits from the "memory" subsystem.
 type MemorySubsystem struct {
-	SubsystemInfo
+	Metadata
 	Mem       MemoryData `json:"mem"`      // Memory usage by tasks in this cgroup.
 	MemSwap   MemoryData `json:"memsw"`    // Memory plus swap usage by tasks in this cgroup.
 	Kernel    MemoryData `json:"kmem"`     // Kernel memory used by tasks in this cgroup.
@@ -61,11 +61,9 @@ type MemoryStat struct {
 	HierarchicalMemswLimit uint64 `json:"hierarchical_memsw_limit"`
 }
 
-// Get reads metrics from the "memory" subsystem. path is the filepath to the
+// get reads metrics from the "memory" subsystem. path is the filepath to the
 // cgroup hierarchy to read.
-func (mem *MemorySubsystem) Get(path string) error {
-	mem.Path = path
-
+func (mem *MemorySubsystem) get(path string) error {
 	if err := memoryData(path, "memory", &mem.Mem); err != nil {
 		return err
 	}

--- a/cgroup/memory_test.go
+++ b/cgroup/memory_test.go
@@ -83,11 +83,10 @@ func TestMemoryDataKernelTCP(t *testing.T) {
 
 func TestMemorySubsystemGet(t *testing.T) {
 	mem := MemorySubsystem{}
-	if err := mem.Get(memoryPath); err != nil {
+	if err := mem.get(memoryPath); err != nil {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, memoryPath, mem.Path)
 	assert.Equal(t, uint64(65101824), mem.Stats.Cache)
 	assert.Equal(t, uint64(295997440), mem.Mem.Usage)
 	assert.Equal(t, uint64(295997440), mem.MemSwap.Usage)
@@ -97,7 +96,7 @@ func TestMemorySubsystemGet(t *testing.T) {
 
 func TestMemorySubsystemJSON(t *testing.T) {
 	mem := MemorySubsystem{}
-	if err := mem.Get(memoryPath); err != nil {
+	if err := mem.get(memoryPath); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cgroup/reader_test.go
+++ b/cgroup/reader_test.go
@@ -7,6 +7,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	path = "/docker/b29faf21b7eff959f64b4192c34d5d67a707fe8561e9eaa608cb27693fba4242"
+	id   = "b29faf21b7eff959f64b4192c34d5d67a707fe8561e9eaa608cb27693fba4242"
+)
+
 func TestReaderGetStats(t *testing.T) {
 	reader, err := NewReader("testdata/docker", true)
 	if err != nil {
@@ -18,10 +23,17 @@ func TestReaderGetStats(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, "testdata/docker/sys/fs/cgroup/blkio/docker/b29faf21b7eff959f64b4192c34d5d67a707fe8561e9eaa608cb27693fba4242", stats.BlockIO.Path)
-	assert.Equal(t, "testdata/docker/sys/fs/cgroup/cpu/docker/b29faf21b7eff959f64b4192c34d5d67a707fe8561e9eaa608cb27693fba4242", stats.CPU.Path)
-	assert.Equal(t, "testdata/docker/sys/fs/cgroup/cpuacct/docker/b29faf21b7eff959f64b4192c34d5d67a707fe8561e9eaa608cb27693fba4242", stats.CPUAccounting.Path)
-	assert.Equal(t, "testdata/docker/sys/fs/cgroup/memory/docker/b29faf21b7eff959f64b4192c34d5d67a707fe8561e9eaa608cb27693fba4242", stats.Memory.Path)
+	assert.Equal(t, id, stats.ID)
+	assert.Equal(t, id, stats.BlockIO.ID)
+	assert.Equal(t, id, stats.CPU.ID)
+	assert.Equal(t, id, stats.CPUAccounting.ID)
+	assert.Equal(t, id, stats.Memory.ID)
+
+	assert.Equal(t, path, stats.Path)
+	assert.Equal(t, path, stats.BlockIO.Path)
+	assert.Equal(t, path, stats.CPU.Path)
+	assert.Equal(t, path, stats.CPUAccounting.Path)
+	assert.Equal(t, path, stats.Memory.Path)
 
 	json, err := json.MarshalIndent(stats, "", "  ")
 	if err != nil {

--- a/cgroup/util.go
+++ b/cgroup/util.go
@@ -17,11 +17,6 @@ var (
 	ErrInvalidFormat = errors.New("error invalid key/value format")
 )
 
-// SubsystemInfo contains fields common to all cgroup subsystems.
-type SubsystemInfo struct {
-	Path string `json:"path,omitempty"`
-}
-
 // Parses a cgroup param and returns the key name and value.
 func parseCgroupParamKeyValue(t string) (string, uint64, error) {
 	parts := strings.Fields(t)


### PR DESCRIPTION
Add a path and ID metadata information to stats from each cgroup subsystem.
Add a path and ID to the cgroup.Stats when the path and ID for each subsystem is the same.