### PR TITLE
Improve error handling on darwin

### DIFF
--- a/sigar_darwin.go
+++ b/sigar_darwin.go
@@ -364,10 +364,16 @@ func kern_procargs(pid int,
 	if exe != nil {
 		exe(string(chop(path)))
 	}
+	if err != nil {
+		return fmt.Errorf("Error reading the argv[0]: %v", err)
+	}
 
 	// skip trailing \0's
 	for {
-		c, _ := bbuf.ReadByte()
+		c, err := bbuf.ReadByte()
+		if err != nil {
+			return fmt.Errorf("Error skipping nils: %v", err)
+		}
 		if c != 0 {
 			bbuf.UnreadByte()
 			break // start of argv[0]
@@ -378,6 +384,9 @@ func kern_procargs(pid int,
 		arg, err := bbuf.ReadBytes(0)
 		if err == io.EOF {
 			break
+		}
+		if err != nil {
+			return fmt.Errorf("Error reading args: %v", err)
 		}
 		if argv != nil {
 			argv(string(chop(arg)))
@@ -394,6 +403,9 @@ func kern_procargs(pid int,
 		line, err := bbuf.ReadBytes(0)
 		if err == io.EOF || line[0] == 0 {
 			break
+		}
+		if err != nil {
+			return fmt.Errorf("Error reading args: %v", err)
 		}
 		pair := bytes.SplitN(chop(line), delim, 2)
 		env(string(pair[0]), string(pair[1]))


### PR DESCRIPTION
Errors were ignored in fairly dangerous places, which could result
in infinite loops. Potential fix for elastic/beats#2747.