### PR TITLE
Fix actual free memory on Windows

### DIFF
--- a/sigar_windows.go
+++ b/sigar_windows.go
@@ -102,9 +102,8 @@ func (self *Mem) Get() error {
 	self.Total = uint64(statex.ullTotalPhys)
 	self.Free = uint64(statex.ullAvailPhys)
 	self.Used = self.Total - self.Free
-	vtotal := uint64(statex.ullTotalVirtual)
-	self.ActualFree = uint64(statex.ullAvailVirtual)
-	self.ActualUsed = vtotal - self.ActualFree
+	self.ActualFree = self.Free
+	self.ActualUsed = self.Used
 
 	return nil
 }


### PR DESCRIPTION
Fixing https://github.com/elastic/beats/issues/2653

On Windows, set the actual free memory equal with the free memory.