### PR TITLE
Fix ProcTime.StartTime on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fix value of `Mem.ActualFree` and `Mem.ActualUsed` on Windows. #49
+- Fix `ProcTime.StartTime` on Windows to report value in milliseconds since Unix epoch. #51

--- a/sigar_interface_test.go
+++ b/sigar_interface_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	. "github.com/elastic/gosigar"
 	"github.com/stretchr/testify/assert"
@@ -111,10 +112,14 @@ func TestProcMem(t *testing.T) {
 }
 
 func TestProcTime(t *testing.T) {
-	time := ProcTime{}
-	assert.NoError(t, time.Get(os.Getppid()))
+	procTime := ProcTime{}
+	if assert.NoError(t, procTime.Get(os.Getppid())) {
+		// Sanity check the start time of the "go test" process.
+		delta := time.Now().Sub(time.Unix(0, int64(procTime.StartTime*uint64(time.Millisecond))))
+		assert.True(t, delta > 0 && delta < 2*time.Minute, "ProcTime.StartTime differs by %v", delta)
+	}
 
-	assert.Error(t, time.Get(invalidPid))
+	assert.Error(t, procTime.Get(invalidPid))
 }
 
 func TestProcArgs(t *testing.T) {

--- a/sigar_windows.go
+++ b/sigar_windows.go
@@ -476,13 +476,14 @@ func (self *ProcTime) Get(pid int) error {
 		return fmt.Errorf("GetProcessTimes fails with %v", err)
 	}
 
-	// convert to millis
-	self.StartTime = uint64(FiletimeToDuration(&CPU.CreationTime).Nanoseconds() / 1e6)
+	// Windows epoch times are expressed as time elapsed since midnight on
+	// January 1, 1601 at Greenwich, England. This converts the Filetime to
+	// unix epoch in milliseconds.
+	self.StartTime = uint64(CPU.CreationTime.Nanoseconds() / 1e6)
 
+	// Convert to millis.
 	self.User = uint64(FiletimeToDuration(&CPU.UserTime).Nanoseconds() / 1e6)
-
 	self.Sys = uint64(FiletimeToDuration(&CPU.KernelTime).Nanoseconds() / 1e6)
-
 	self.Total = self.User + self.Sys
 
 	return nil


### PR DESCRIPTION
This converts the process creation time from Windows epoch to milliseconds since unix epoch. A test was added to sanity check the StartTime value.

> Process creation and exit times are points in time expressed as the amount of time that has elapsed since midnight on January 1, 1601 at Greenwich, England.

Source: https://msdn.microsoft.com/en-us/library/windows/desktop/ms683223