### PR TITLE
Add AuditClient for communicating to the Linux kernel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Files
 .DS_Store
 /*.iml
+*.h
 
 # Editor swap files
 *.swp
@@ -23,6 +24,8 @@
 *.swp
 
 # Example binaries
+examples/audit/audit
+examples/audit/audit.exe
 examples/df/df
 examples/df/df.exe
 examples/free/free

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
   - osx
 
 go:
-  - 1.7.4
+  - 1.8
 
 env:
   global:
@@ -30,7 +30,7 @@ script:
   - go build
   - mkdir -p build/coverage
   - gotestcover -v -coverprofile=build/coverage/unit.cov github.com/elastic/gosigar/...
-  - for i in $(ls examples); do go build -o examples/$i/$i ./examples/$i; ./examples/$i/$i; done
+  - for i in $(ls examples | grep -v audit); do go build -o examples/$i/$i ./examples/$i; ./examples/$i/$i; done
 
 after_success:
   - bash <(curl -s https://codecov.io/bash) -f build/coverage/unit.cov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Added `AuditClient` for communicating to the Linux kernel's audit interface
+  via netlink. #66
 
 ### Changed
 

--- a/examples/audit/audit.go
+++ b/examples/audit/audit.go
@@ -1,0 +1,109 @@
+// +build linux
+
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/elastic/gosigar/sys/linux"
+	"github.com/pkg/errors"
+)
+
+var (
+	fs     = flag.NewFlagSet("audit", flag.ExitOnError)
+	debug  = fs.Bool("d", false, "enable debug output to stderr")
+	diag   = fs.String("diag", "", "dump raw information from kernel to file")
+	pretty = fs.Bool("pretty", false, "pretty print json output")
+)
+
+func enableLogger() {
+	log.SetOutput(os.Stderr)
+	log.SetLevel(log.DebugLevel)
+	log.SetFormatter(&log.TextFormatter{
+		FullTimestamp:   true,
+		TimestampFormat: time.RFC3339Nano,
+	})
+}
+
+func main() {
+	fs.Parse(os.Args[1:])
+
+	if *debug {
+		enableLogger()
+	}
+
+	if err := read(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func read() error {
+	if os.Geteuid() != 0 {
+		return errors.New("you must be root to receive audit data")
+	}
+
+	// Write netlink response to a file for further analysis or for writing
+	// tests cases.
+	var diagWriter io.Writer
+	if *diag != "" {
+		f, err := os.OpenFile(*diag, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0600)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		diagWriter = f
+	}
+
+	log.Debugln("starting netlink client")
+	client, err := linux.NewAuditClient(diagWriter)
+	if err != nil {
+		return err
+	}
+
+	log.Debugln("sending message to kernel registering our PID as the audit daemon")
+	if err = client.SetPortID(0); err != nil {
+		return errors.Wrap(err, "failed to set audit PID")
+	}
+
+	for {
+		m, err := client.Receive(false)
+		if err != nil {
+			return errors.Wrap(err, "receive failed")
+		}
+
+		if m.MessageType < 1300 || m.MessageType >= 2100 {
+			continue
+		}
+
+		// Ignore AUDIT_EOE.
+		if m.MessageType == 1320 {
+			continue
+		}
+
+		event := map[string]interface{}{
+			"type": m.MessageType,
+			"msg":  string(m.RawData),
+		}
+
+		var jsonEvent []byte
+		if *pretty {
+			jsonEvent, err = json.MarshalIndent(event, "", "  ")
+		} else {
+			jsonEvent, err = json.Marshal(event)
+		}
+		if err != nil {
+			log.WithError(err).Warn("Failed to marshal event to JSON")
+		}
+
+		fmt.Println(string(jsonEvent))
+	}
+
+	return nil
+}

--- a/sys/linux/audit.go
+++ b/sys/linux/audit.go
@@ -1,0 +1,319 @@
+// +build linux
+
+package linux
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	// AuditMessageMaxLength is the maximum length of an audit message (data
+	// portion of a NetlinkMessage).
+	// https://github.com/linux-audit/audit-userspace/blob/990aa27ccd02f9743c4f4049887ab89678ab362a/lib/libaudit.h#L435
+	AuditMessageMaxLength = 8970
+)
+
+// Audit command and control message types.
+const (
+	AuditGet uint16 = iota + 1000
+	AuditSet
+)
+
+// AuditClient is a client for communicating with the Linux kernels audit
+// interface over netlink.
+type AuditClient struct {
+	netlink *NetlinkClient
+}
+
+// NewAuditClient creates a new AuditClient. The resp parameter is optional. If
+// provided resp will receive a copy of all data read from the netlink socket.
+// This is useful for debugging purposes.
+func NewAuditClient(resp io.Writer) (*AuditClient, error) {
+	buf := make([]byte, AuditMessageMaxLength)
+
+	netlink, err := NewNetlinkClient(syscall.NETLINK_AUDIT, buf, resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AuditClient{netlink: netlink}, nil
+}
+
+// GetNetlinkPortID returns the port ID of the underlying netlink socket.
+func (c *AuditClient) GetNetlinkPortID() int {
+	return int(c.netlink.pid)
+}
+
+// GetStatus returns the current status of the kernel's audit subsystem.
+func (c *AuditClient) GetStatus() (*AuditStatus, error) {
+	msg := syscall.NetlinkMessage{
+		Header: syscall.NlMsghdr{
+			Type:  AuditGet,
+			Flags: syscall.NLM_F_REQUEST | syscall.NLM_F_ACK,
+		},
+		Data: nil,
+	}
+
+	// Send AUDIT_GET message to the kernel.
+	seq, err := c.netlink.Send(msg)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed sending request")
+	}
+
+	// Get the ack message which is a NLMSG_ERROR type whose error code is SUCCESS.
+	ack, err := c.getReply(seq)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get audit status ack")
+	}
+
+	if ack.Header.Type != syscall.NLMSG_ERROR {
+		return nil, errors.Errorf("unexpected ACK to GET, type=%d", ack.Header.Type)
+	}
+
+	if err := ParseNetlinkError(ack.Data); err != NLE_SUCCESS {
+		if len(ack.Data) >= 4+12 {
+			status := &AuditStatus{}
+			if err := status.fromWireFormat(ack.Data[4:]); err == nil {
+				return nil, syscall.Errno(status.Failure)
+			}
+		}
+		return nil, err
+	}
+
+	// Get the audit_status reply message. It has the same sequence number as
+	// our original request.
+	reply, err := c.getReply(seq)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get audit status reply")
+	}
+
+	if reply.Header.Type != AuditGet {
+		return nil, errors.Errorf("unexpected reply to GET, type%d", reply.Header.Type)
+	}
+
+	replyStatus := &AuditStatus{}
+	if err := replyStatus.fromWireFormat(reply.Data); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal reply")
+	}
+
+	return replyStatus, nil
+}
+
+// SetPortID sends a netlink message to the kernel telling it the port ID of
+// netlink listener that should receive the audit messages.
+// https://github.com/linux-audit/audit-userspace/blob/990aa27ccd02f9743c4f4049887ab89678ab362a/lib/libaudit.c#L432-L464
+func (c *AuditClient) SetPortID(pid int) error {
+	netlinkPID := uint32(pid)
+	if netlinkPID == 0 {
+		netlinkPID = c.netlink.pid
+	}
+
+	status := AuditStatus{
+		Mask:    AuditStatusEnabled | AuditStatusPID,
+		Enabled: 1,
+		PID:     netlinkPID,
+	}
+	return c.set(status)
+}
+
+// RawAuditMessage is a raw audit message received from the kernel.
+type RawAuditMessage struct {
+	MessageType uint16
+	RawData     []byte // RawData is backed by the read buffer so make a copy.
+}
+
+// Receive reads an audit message from the netlink socket. If you are going to
+// use the returned message then you should make a copy of the raw data before
+// calling receive again because the raw data is backed by the read buffer.
+func (c *AuditClient) Receive(nonBlocking bool) (*RawAuditMessage, error) {
+	msgs, err := c.netlink.Receive(nonBlocking, parseNetlinkAuditMessage)
+	if err != nil {
+		return nil, err
+	}
+
+	// ParseNetlinkAuditMessage always return a slice with 1 item.
+	return &RawAuditMessage{
+		MessageType: msgs[0].Header.Type,
+		RawData:     msgs[0].Data,
+	}, nil
+}
+
+// Close closes the AuditClient and frees any associated resources.
+func (c *AuditClient) Close() error {
+	return c.netlink.Close()
+}
+
+// getReply reads from the netlink socket and find the message with the given
+// sequence number. The caller should inspect the returned message's type,
+// flags, and error code.
+func (c *AuditClient) getReply(seq uint32) (*syscall.NetlinkMessage, error) {
+	var msgs []syscall.NetlinkMessage
+	var err error
+
+	// Retry the non-blocking read multiple times until a response is received.
+	for i := 0; i < 10; i++ {
+		msgs, err = c.netlink.Receive(true, syscall.ParseNetlinkMessage)
+		if err != nil {
+			switch err {
+			case syscall.EINTR:
+				continue
+			case syscall.EAGAIN:
+				time.Sleep(50 * time.Millisecond)
+				continue
+			default:
+				return nil, errors.Wrap(err, "error receiving audit netlink packet")
+			}
+		}
+
+		break
+	}
+
+	if len(msgs) == 0 || msgs[0].Header.Seq != seq {
+		return nil, errors.New("no reply received")
+	}
+
+	msg := msgs[0]
+	return &msg, nil
+}
+
+func (c *AuditClient) set(status AuditStatus) error {
+	msg := syscall.NetlinkMessage{
+		Header: syscall.NlMsghdr{
+			Type:  AuditSet,
+			Flags: syscall.NLM_F_REQUEST | syscall.NLM_F_ACK,
+		},
+		Data: status.toWireFormat(),
+	}
+
+	seq, err := c.netlink.Send(msg)
+	if err != nil {
+		return errors.Wrap(err, "failed sending request")
+	}
+
+	ack, err := c.getReply(seq)
+	if err != nil {
+		return err
+	}
+
+	if ack.Header.Type != syscall.NLMSG_ERROR {
+		return errors.Errorf("unexpected ACK to SET, type=%d", ack.Header.Type)
+	}
+
+	if err := ParseNetlinkError(ack.Data); err != NLE_SUCCESS {
+		if len(ack.Data) >= 4+12 {
+			status := &AuditStatus{}
+			if err := status.fromWireFormat(ack.Data[4:]); err == nil {
+				return syscall.Errno(status.Failure)
+			}
+		}
+		return err
+	}
+
+	return nil
+}
+
+// parseNetlinkAuditMessage parses an audit message received from the kernel.
+// Audit messages differ significantly from typical netlink messages in that
+// a single message is sent and the length in the header should be ignored.
+// This is why syscall.ParseNetlinkMessage is not used.
+func parseNetlinkAuditMessage(buf []byte) ([]syscall.NetlinkMessage, error) {
+	if len(buf) < syscall.NLMSG_HDRLEN {
+		return nil, syscall.EINVAL
+	}
+
+	r := bytes.NewReader(buf)
+	m := syscall.NetlinkMessage{}
+	if err := binary.Read(r, binary.LittleEndian, &m.Header); err != nil {
+		return nil, err
+	}
+	m.Data = buf[syscall.NLMSG_HDRLEN:]
+
+	return []syscall.NetlinkMessage{m}, nil
+}
+
+// audit_status message
+
+// AuditStatusMask is a bitmask used to convey the fields used in AuditStatus.
+// https://github.com/linux-audit/audit-kernel/blob/v4.7/include/uapi/linux/audit.h#L318-L325
+type AuditStatusMask uint32
+
+// Mask types for AuditStatus.
+const (
+	AuditStatusEnabled AuditStatusMask = 1 << iota
+	AuditStatusFailure
+	AuditStatusPID
+	AuditStatusRateLimit
+	AuditStatusBacklogLimit
+	AuditStatusBacklogWaitTime
+)
+
+var sizeofAuditStatus = int(unsafe.Sizeof(AuditStatus{}))
+
+// AuditStatus is a status message and command and control message exchanged
+// between the kernel and user-space.
+// https://github.com/linux-audit/audit-kernel/blob/v4.7/include/uapi/linux/audit.h#L413-L427
+type AuditStatus struct {
+	Mask            AuditStatusMask // Bit mask for valid entries.
+	Enabled         uint32          // 1 = enabled, 0 = disabled
+	Failure         uint32          // Failure-to-log action.
+	PID             uint32          // PID of auditd process.
+	RateLimit       uint32          // Messages rate limit (per second).
+	BacklogLimit    uint32          // Waiting messages limit.
+	Lost            uint32          // Messages lost.
+	Backlog         uint32          // Messages waiting in queue.
+	FeatureBitmap   uint32          // Bitmap of kernel audit features (previously to 3.19 it was the audit api version number).
+	BacklogWaitTime uint32          // Message queue wait timeout.
+}
+
+func (s AuditStatus) toWireFormat() []byte {
+	buf := bytes.NewBuffer(make([]byte, sizeofInetDiagReqV2))
+	buf.Reset()
+	if err := binary.Write(buf, binary.LittleEndian, s); err != nil {
+		// This never returns an error.
+		panic(err)
+	}
+	return buf.Bytes()
+}
+
+// fromWireFormat unmarshals the given buffer to an AuditStatus object. Due to
+// changes in the audit_status struct in the kernel source this method does
+// not return an error if the buffer is smaller than the sizeof our AuditStatus
+// struct.
+func (s *AuditStatus) fromWireFormat(buf []byte) error {
+	fields := []interface{}{
+		&s.Mask,
+		&s.Enabled,
+		&s.Failure,
+		&s.PID,
+		&s.RateLimit,
+		&s.BacklogLimit,
+		&s.Lost,
+		&s.Backlog,
+		&s.FeatureBitmap,
+		&s.BacklogWaitTime,
+	}
+
+	if len(buf) == 0 {
+		return io.EOF
+	}
+
+	r := bytes.NewReader(buf)
+	for _, f := range fields {
+		if r.Len() == 0 {
+			return nil
+		}
+
+		if err := binary.Read(r, binary.LittleEndian, f); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/sys/linux/audit_test.go
+++ b/sys/linux/audit_test.go
@@ -1,0 +1,78 @@
+// +build linux
+
+package linux
+
+import (
+	"encoding/hex"
+	"flag"
+	"io"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var hexdump = flag.Bool("hexdump", false, "dump kernel responses to stdout in hexdump -C format")
+
+func TestAuditClientGetStatus(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("must be root to get audit status")
+	}
+
+	status, err := getStatus(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("Status: %+v", status)
+}
+
+func TestAuditClientGetStatusPermissionError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("must be non-root to test permission failure")
+	}
+
+	status, err := getStatus(t)
+	assert.Nil(t, status, "status should be nil")
+	assert.Equal(t, syscall.EPERM, err)
+}
+
+func getStatus(t testing.TB) (*AuditStatus, error) {
+	var dumper io.WriteCloser
+	if *hexdump {
+		dumper = hex.Dumper(os.Stdout)
+		defer dumper.Close()
+	}
+
+	c, err := NewAuditClient(dumper)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	return c.GetStatus()
+}
+
+func TestAuditClientSetPID(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("must be root to set audit port id")
+	}
+
+	var dumper io.WriteCloser
+	if *hexdump {
+		dumper = hex.Dumper(os.Stdout)
+		defer dumper.Close()
+	}
+
+	c, err := NewAuditClient(dumper)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	err = c.SetPortID(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/sys/linux/netlink.go
+++ b/sys/linux/netlink.go
@@ -1,9 +1,172 @@
+// +build linux
+
 package linux
 
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync/atomic"
+	"syscall"
 )
+
+// Generic Netlink Client
+
+// NetlinkSender sends a netlink message and returns the sequence number used
+// in the message and an error if it occurred.
+type NetlinkSender interface {
+	Send(msg syscall.NetlinkMessage) (uint32, error)
+}
+
+// NetlinkReceiver receives data from the netlink socket and uses the provided
+// parser to convert the raw bytes to NetlinkMessages. For most uses cases
+// syscall.ParseNetlinkMessage should be used. If nonBlocking is true then
+// instead of blocking when no data is available, EWOULDBLOCK is returned.
+type NetlinkReceiver interface {
+	Receive(nonBlocking bool, p NetlinkParser) ([]syscall.NetlinkMessage, error)
+}
+
+// NetlinkSendReceiver combines the Send and Receive into one interface.
+type NetlinkSendReceiver interface {
+	NetlinkSender
+	NetlinkReceiver
+}
+
+// NetlinkParser parses the raw bytes read from the netlink socket into
+// netlink messages.
+type NetlinkParser func([]byte) ([]syscall.NetlinkMessage, error)
+
+// NetlinkClient is a generic client for sending and receiving netlink messages.
+type NetlinkClient struct {
+	fd         int              // File descriptor used for communication.
+	src        syscall.Sockaddr // Local socket address.
+	dest       syscall.Sockaddr // Remote socket address (client assumes the dest is the kernel).
+	pid        uint32           // Port ID of the local socket.
+	seq        uint32           // Sequence number used in outgoing messages.
+	readBuf    []byte
+	respWriter io.Writer
+}
+
+// NewNetlinkClient creates a new NetlinkClient. It creates a socket and binds
+// it. readBuf is an optional byte buffer used for reading data from the socket.
+// The size of the buffer limits the maximum message size the can be read. If no
+// buffer is provided one will be allocated using the OS page size. resp is
+// optional and can be used to receive a copy of all bytes read from the socket
+// (this is useful for debugging).
+//
+// The returned NetlinkClient must be closed with Close() when finished.
+func NewNetlinkClient(proto int, readBuf []byte, resp io.Writer) (*NetlinkClient, error) {
+	s, err := syscall.Socket(syscall.AF_NETLINK, syscall.SOCK_RAW, proto)
+	if err != nil {
+		return nil, err
+	}
+
+	src := &syscall.SockaddrNetlink{Family: syscall.AF_NETLINK}
+	if err = syscall.Bind(s, src); err != nil {
+		syscall.Close(s)
+		return nil, err
+	}
+
+	pid, err := getPortID(s)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(readBuf) == 0 {
+		// Default size used in libnl.
+		readBuf = make([]byte, os.Getpagesize())
+	}
+
+	return &NetlinkClient{
+		fd:         s,
+		src:        src,
+		dest:       &syscall.SockaddrNetlink{},
+		pid:        pid,
+		readBuf:    readBuf,
+		respWriter: resp,
+	}, nil
+}
+
+// getPortID gets the kernel assigned port ID (PID) of the local netlink socket.
+// The kernel assigns the processes PID to the first socket then assigns arbitrary values
+// to any follow-on sockets. See man netlink for details.
+func getPortID(fd int) (uint32, error) {
+	address, err := syscall.Getsockname(fd)
+	if err != nil {
+		return 0, err
+	}
+
+	addr, ok := address.(*syscall.SockaddrNetlink)
+	if !ok {
+		return 0, errors.New("unexpected socket address type")
+	}
+
+	return addr.Pid, nil
+}
+
+// Send sends a netlink message and returns the sequence number used
+// in the message and an error if it occurred. If the PID is not set then
+// the value will be populated automatically (recommended).
+func (c *NetlinkClient) Send(msg syscall.NetlinkMessage) (uint32, error) {
+	if msg.Header.Pid == 0 {
+		msg.Header.Pid = c.pid
+	}
+
+	msg.Header.Seq = atomic.AddUint32(&c.seq, 1)
+	to := &syscall.SockaddrNetlink{}
+	return msg.Header.Seq, syscall.Sendto(c.fd, serialize(msg), 0, to)
+}
+
+// Receive receives data from the netlink socket and uses the provided
+// parser to convert the raw bytes to NetlinkMessages. See NetlinkReceiver docs.
+func (c *NetlinkClient) Receive(nonBlocking bool, p NetlinkParser) ([]syscall.NetlinkMessage, error) {
+	var flags int
+	if nonBlocking {
+		flags |= syscall.MSG_DONTWAIT
+	}
+
+	// XXX (akroh): A possible enhancement is to use the MSG_PEEK flag to
+	// check the message size and increase the buffer size to handle it all.
+	nr, from, err := syscall.Recvfrom(c.fd, c.readBuf, flags)
+	if err != nil {
+		// EAGAIN or EWOULDBLOCK will be returned for non-blocking reads where
+		// the read would normally have blocked.
+		return nil, err
+	}
+	if nr < syscall.NLMSG_HDRLEN {
+		return nil, syscall.EINVAL
+	}
+	fromNetlink, ok := from.(*syscall.SockaddrNetlink)
+	if !ok || fromNetlink.Pid != 0 {
+		// Spoofed packet received on audit netlink socket.
+		return nil, syscall.EINVAL
+	}
+
+	buf := c.readBuf[:nr]
+
+	// Dump raw data for inspection purposes.
+	if c.respWriter != nil {
+		if _, err := c.respWriter.Write(buf); err != nil {
+			return nil, err
+		}
+	}
+
+	msgs, err := p(buf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse netlink messages: %v", err)
+	}
+
+	return msgs, nil
+}
+
+// Close closes the netlink client's raw socket.
+func (c *NetlinkClient) Close() error {
+	return syscall.Close(c.fd)
+}
+
+// Netlink Error Code Handling
 
 // ParseNetlinkError parses the errno from the data section of a
 // syscall.NetlinkMessage. If netlinkData is less than 4 bytes an error

--- a/sys/linux/netlink_test.go
+++ b/sys/linux/netlink_test.go
@@ -1,12 +1,19 @@
+// +build linux
+
 package linux
 
 import (
 	"bytes"
 	"encoding/binary"
+	"os"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// Validate NetlinkClient implements NetlinkSendReceiver.
+var _ NetlinkSendReceiver = &NetlinkClient{}
 
 func TestParseNetlinkErrorDataTooShort(t *testing.T) {
 	assert.Error(t, ParseNetlinkError(nil), "too short")
@@ -16,4 +23,27 @@ func TestParseNetlinkErrorErrno(t *testing.T) {
 	buf := new(bytes.Buffer)
 	binary.Write(buf, binary.LittleEndian, -1*int32(NLE_MSG_TOOSHORT))
 	assert.Equal(t, ParseNetlinkError(buf.Bytes()), NLE_MSG_TOOSHORT)
+}
+
+func TestNewNetlinkClient(t *testing.T) {
+	c, err := NewNetlinkClient(syscall.NETLINK_AUDIT, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	assert.Len(t, c.readBuf, os.Getpagesize())
+
+	// First PID assigned by the kernel will be our actual PID.
+	assert.EqualValues(t, os.Getpid(), c.pid)
+
+	c2, err := NewNetlinkClient(syscall.NETLINK_AUDIT, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c2.Close()
+
+	// Second PID assigned by kernel will be random.
+	assert.NotEqual(t, 0, c2.pid)
+	assert.NotEqual(t, c.pid, c2.pid)
 }


### PR DESCRIPTION
Added `AuditClient` for communicating to the Linux kernel's audit interface
via netlink.