### PR TITLE
Add control methods to AuditClient

### DIFF
--- a/examples/audit/audit.go
+++ b/examples/audit/audit.go
@@ -83,8 +83,19 @@ func read() error {
 		return err
 	}
 
+	status, err := client.GetStatus()
+	if err != nil {
+		return errors.Wrap(err, "failed to get audit status")
+	}
+	log.WithField("status", status).Info("received audit status")
+
+	log.Debugln("enabling auditing in the kernel")
+	if err = client.SetEnabled(true); err != nil {
+		return errors.Wrap(err, "failed to set enabled=true")
+	}
+
 	log.Debugln("sending message to kernel registering our PID as the audit daemon")
-	if err = client.SetPortID(0); err != nil {
+	if err = client.SetPID(linux.WaitForReply); err != nil {
 		return errors.Wrap(err, "failed to set audit PID")
 	}
 


### PR DESCRIPTION
Added `SetEnabled`, `SetRateLimit`, and `SetBacklogLimit`.

These changes were tested on RHEL7. I also experimented with testing in a container
with mostly positive results. This depends largely on the kernel version because
newer kernels check for things like pid namespacing. For reference the command I used was

`docker run -it -v `pwd`:/go/src/github.com/elastic/gosigar --pid=host --cap-add=AUDIT_CONTROL golang:1.8 /bin/bash`