### PR TITLE
Use MemAvailable when it's available on Linux 3.14+ kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Read `MemAvailable` value for kernel 3.14+
 
 ### Changed
 


### PR DESCRIPTION
Use MemAvailable when it's available on Linux 3.14+ kernel, otherwise calculate it as free memory plus the caches and buffers.

(Fixes https://github.com/elastic/beats/issues/4202)