### PR TITLE
Fix hang during init on Windows if WMI is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Fixed Windows issue that caused a hang during `init()` if WMI wasn't ready. #74
 
 ### Deprecated
 

--- a/sigar_windows.go
+++ b/sigar_windows.go
@@ -49,14 +49,6 @@ func init() {
 		// PROCESS_QUERY_LIMITED_INFORMATION cannot be used on 2003 or XP.
 		processQueryLimitedInfoAccess = syscall.PROCESS_QUERY_INFORMATION
 	}
-
-	if version.IsWindowsVistaOrGreater() {
-		// The minimum supported client for Win32_OperatingSystem is Windows Vista.
-		os, err := getWin32OperatingSystem()
-		if err == nil {
-			bootTime = &os.LastBootUpTime
-		}
-	}
 }
 
 func (self *LoadAverage) Get() error {
@@ -82,7 +74,15 @@ func (self *ProcFDUsage) Get(pid int) error {
 func (self *Uptime) Get() error {
 	if bootTime == nil {
 		// Minimum supported OS is Windows Vista.
-		return ErrNotImplemented{runtime.GOOS}
+		if !version.IsWindowsVistaOrGreater() {
+			return ErrNotImplemented{runtime.GOOS}
+		}
+
+		os, err := getWin32OperatingSystem()
+		if err != nil {
+			return errors.Wrap(err, "failed to get boot time using WMI")
+		}
+		bootTime = &os.LastBootUpTime
 	}
 
 	self.Length = time.Since(*bootTime).Seconds()


### PR DESCRIPTION
This issue affected Windows Vista and newer. During the `init()` phase a WMI call was made to get the system boot time. If WMI wasn't fully up the call would hang which blocked the entire application from initializing.