### PR TITLE
MINOR: kern_procargs more robust on darwin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Fixed Trim environment variables when comparing values in the test suite. #79
+- Make kern_procargs more robust under darwin when we cannot retrieve
+  all the information about a process. #78
 
 ### Deprecated
 

--- a/sigar_darwin.go
+++ b/sigar_darwin.go
@@ -420,6 +420,11 @@ func kern_procargs(pid int,
 			return fmt.Errorf("Error reading args: %v", err)
 		}
 		pair := bytes.SplitN(chop(line), delim, 2)
+
+		if len(pair) != 2 {
+			return fmt.Errorf("Error reading process information for PID: %d", pid)
+		}
+
 		env(string(pair[0]), string(pair[1]))
 	}
 


### PR DESCRIPTION
Under some circonstance the code can fail, the root cause is not clear
at the moment, but we should still make the code more robust when
retrieving information for a specific process.

The problem is the `bytes.SplitN` can return an array of one element
making the process panic when we access the other element.

This commit make the code a bit more robust and check to make sure we
successfully retrieved 2 elements instead of one and return an error
if it failed.

Reference: elastic/beats#5337