### PR TITLE
MINOR: trim environment variable values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Fixed Trim environment variables when comparing values in the test suite. #79
 
 ### Deprecated
 

--- a/sigar_interface_test.go
+++ b/sigar_interface_test.go
@@ -5,6 +5,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -134,7 +135,7 @@ func TestProcEnv(t *testing.T) {
 		assert.True(t, len(env.Vars) > 0, "env is empty")
 
 		for k, v := range env.Vars {
-			assert.Equal(t, os.Getenv(k), v)
+			assert.Equal(t, strings.TrimSpace(os.Getenv(k)), v)
 		}
 	}
 }


### PR DESCRIPTION
When working on #78, I was hit by a test failing on linux (debian host)
Our code is triming values so we need to adjust the test code to make
sure we also trim values before doing the comparison.

Example:
```
	expected: "${debian_chroot:+($debian_chroot)}\\u@\\h:\\w\\$ "
	            	actual: "${debian_chroot:+($debian_chroot)}\\u@\\h:\\w\\$"
```