### PR TITLE
Fix incorrect Mem.Used calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - OpenBSD returns `ErrNotImplemented` for `ProcTime.Get` instead of `nil`. #83
+- Fixed incorrect `Mem.Used` calculation under linux. #82
 
 ### Deprecated
 

--- a/sigar_linux_common.go
+++ b/sigar_linux_common.go
@@ -71,7 +71,7 @@ func (self *Mem) Get() error {
 		self.ActualFree = self.Free + buffers + cached
 	}
 
-	self.Used = self.Total - self.ActualFree
+	self.Used = self.Total - self.Free
 	self.ActualUsed = self.Total - self.ActualFree
 
 	return nil

--- a/sigar_linux_test.go
+++ b/sigar_linux_test.go
@@ -209,6 +209,9 @@ DirectMap2M:      333824 kB
 	if assert.NoError(t, mem.Get()) {
 		assert.Equal(t, uint64(374256*1024), mem.Total)
 		assert.Equal(t, uint64(274460*1024), mem.Free)
+		assert.Equal(t, uint64(mem.Total-mem.Free), mem.Used)
+		assert.Equal(t, uint64((274460+9764+38648)*1024), mem.ActualFree)
+		assert.Equal(t, uint64(mem.Total-mem.ActualFree), mem.ActualUsed)
 	}
 
 	swap := sigar.Swap{}
@@ -281,6 +284,8 @@ DirectMap2M:      460800 kB
 		assert.Equal(t, uint64(500184*1024), mem.Total)
 		assert.Equal(t, uint64(31360*1024), mem.Free)
 		assert.Equal(t, uint64(414168*1024), mem.ActualFree)
+		assert.Equal(t, uint64(mem.Total-mem.Free), mem.Used)
+		assert.Equal(t, uint64(mem.Total-mem.ActualFree), mem.ActualUsed)
 	}
 
 	swap := sigar.Swap{}


### PR DESCRIPTION
I think this  obviously must be fixed. directly cause system/memory metrics fetching incorrect