### PR TITLE
Changes to support CPU usage metric in Beats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,18 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Added method stubs to enable compilation for operating systems that are not
+  supported by gosigar. All methods return `ErrNotImplemented` on these unsupported
+  operating systems. #83
+- FreeBSD returns `ErrNotImplemented` for `ProcTime.Get` #83
 
 ### Changed
+- OpenBSD returns `ErrNotImplemented` for `ProcTime.Get` instead of `nil` #83
 
 ### Deprecated
 
 ### Removed
+- Remove NetBSD build from sigar_unix.go as it is not supported by gosigar #83
 
 ## [0.5.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added method stubs to enable compilation for operating systems that are not
   supported by gosigar. All methods return `ErrNotImplemented` on these unsupported
   operating systems. #83
-- FreeBSD returns `ErrNotImplemented` for `ProcTime.Get` #83
+- FreeBSD returns `ErrNotImplemented` for `ProcTime.Get`. #83
 
 ### Changed
-- OpenBSD returns `ErrNotImplemented` for `ProcTime.Get` instead of `nil` #83
+- OpenBSD returns `ErrNotImplemented` for `ProcTime.Get` instead of `nil`. #83
 
 ### Deprecated
 
 ### Removed
-- Remove NetBSD build from sigar_unix.go as it is not supported by gosigar #83
+- Remove NetBSD build from sigar_unix.go as it is not supported by gosigar. #83
 
 ## [0.5.0]
 

--- a/sigar_freebsd.go
+++ b/sigar_freebsd.go
@@ -4,6 +4,7 @@ package gosigar
 
 import (
 	"io/ioutil"
+	"runtime"
 	"strconv"
 	"strings"
 	"unsafe"
@@ -105,4 +106,8 @@ func parseCpuStat(self *Cpu, line string) error {
 	self.Sys, _ = strtoull(fields[3])
 	self.Idle, _ = strtoull(fields[4])
 	return nil
+}
+
+func (self *ProcTime) Get(pid int) error {
+	return ErrNotImplemented{runtime.GOOS}
 }

--- a/sigar_openbsd.go
+++ b/sigar_openbsd.go
@@ -370,7 +370,7 @@ func (self *ProcMem) Get(pid int) error {
 }
 
 func (self *ProcTime) Get(pid int) error {
-	return nil
+	return ErrNotImplemented{runtime.GOOS}
 }
 
 func (self *ProcExe) Get(pid int) error {

--- a/sigar_stub.go
+++ b/sigar_stub.go
@@ -1,0 +1,35 @@
+// +build !darwin,!freebsd,!linux,!openbsd,!windows
+
+package gosigar
+
+import (
+	"runtime"
+)
+
+func (c *Cpu) Get() error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
+func (l *LoadAverage) Get() error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
+func (m *Mem) Get() error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
+func (s *Swap) Get() error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
+func (f *FDUsage) Get() error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
+func (p *ProcTime) Get(int) error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
+func (self *FileSystemUsage) Get(path string) error {
+	return ErrNotImplemented{runtime.GOOS}
+}

--- a/sigar_unix.go
+++ b/sigar_unix.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2012 VMware, Inc.
 
-// +build darwin freebsd linux netbsd
+// +build darwin freebsd linux
 
 package gosigar
 


### PR DESCRIPTION
* remove netbsd from `sigar_unix` as it is not supported
* add `sigar_stub` to provide stubs for unsupported functions
* add stubs for freebsd and fix openbsd for `ProcTime.Get`

These changes are required by https://github.com/elastic/beats/pull/5545