### PR TITLE
Fix ProcState parsing for process names with parantheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - OpenBSD returns `ErrNotImplemented` for `ProcTime.Get` instead of `nil`. #83
+- Fixed `ProcState` on Linux and FreeBSD when process names contain parentheses. #81
 
 ### Deprecated
 

--- a/sigar_linux_common.go
+++ b/sigar_linux_common.go
@@ -7,7 +7,6 @@ package gosigar
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -181,44 +180,58 @@ func (self *ProcList) Get() error {
 }
 
 func (self *ProcState) Get(pid int) error {
-	contents, err := readProcFile(pid, "stat")
+	data, err := readProcFile(pid, "stat")
 	if err != nil {
 		return err
 	}
 
-	headerAndStats := strings.SplitAfterN(string(contents), ")", 2)
-	pidAndName := headerAndStats[0]
-	fields := strings.Fields(headerAndStats[1])
+	// Extract the comm value with is surrounded by parentheses.
+	lIdx := bytes.Index(data, []byte("("))
+	rIdx := bytes.LastIndex(data, []byte(")"))
+	if lIdx < 0 || rIdx < 0 {
+		return fmt.Errorf("failed to extract comm for pid %d from '%v'", pid, string(data))
+	}
+	self.Name = string(data[lIdx+1 : rIdx])
 
-	name := strings.SplitAfterN(pidAndName, " ", 2)[1]
-	if name[0] == '(' && name[len(name)-1] == ')' {
-		self.Name = name[1 : len(name)-1] // strip ()'s
-	} else {
-		return errors.New(fmt.Sprintf("Malformed process stats for pid %d", pid))
+	// Extract the rest of the fields that we are interested in.
+	fields := bytes.Fields(data[rIdx+2:])
+	if len(fields) <= 36 {
+		return fmt.Errorf("expected more stat fields for pid %d from '%v'", pid, string(data))
 	}
 
-	self.State = RunState(fields[0][0])
+	interests := bytes.Join([][]byte{
+		fields[0],  // state
+		fields[1],  // ppid
+		fields[2],  // pgrp
+		fields[4],  // tty_nr
+		fields[15], // priority
+		fields[16], // nice
+		fields[36], // processor (last processor executed on)
+	}, []byte(" "))
 
-	self.Ppid, _ = strconv.Atoi(fields[1])
-
-	self.Pgid, _ = strconv.Atoi(fields[2])
-
-	self.Tty, _ = strconv.Atoi(fields[4])
-
-	self.Priority, _ = strconv.Atoi(fields[15])
-
-	self.Nice, _ = strconv.Atoi(fields[16])
-
-	self.Processor, _ = strconv.Atoi(fields[36])
+	var state string
+	_, err = fmt.Fscan(bytes.NewBuffer(interests),
+		&state,
+		&self.Ppid,
+		&self.Pgid,
+		&self.Tty,
+		&self.Priority,
+		&self.Nice,
+		&self.Processor,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to parse stat fields for pid %d from '%v': %v", pid, string(data), err)
+	}
+	self.State = RunState(state[0])
 
 	// Read /proc/[pid]/status to get the uid, then lookup uid to get username.
 	status, err := getProcStatus(pid)
 	if err != nil {
-		return fmt.Errorf("failed to read process status for pid %d. %v", pid, err)
+		return fmt.Errorf("failed to read process status for pid %d: %v", pid, err)
 	}
 	uids, err := getUIDs(status)
 	if err != nil {
-		return fmt.Errorf("failed to read process status for pid %d. %v", pid, err)
+		return fmt.Errorf("failed to read process status for pid %d: %v", pid, err)
 	}
 	user, err := user.LookupId(uids[0])
 	if err == nil {

--- a/sigar_linux_common.go
+++ b/sigar_linux_common.go
@@ -188,7 +188,7 @@ func (self *ProcState) Get(pid int) error {
 	// Extract the comm value with is surrounded by parentheses.
 	lIdx := bytes.Index(data, []byte("("))
 	rIdx := bytes.LastIndex(data, []byte(")"))
-	if lIdx < 0 || rIdx < 0 {
+	if lIdx < 0 || rIdx < 0 || lIdx >= rIdx || rIdx+2 >= len(data) {
 		return fmt.Errorf("failed to extract comm for pid %d from '%v'", pid, string(data))
 	}
 	self.Name = string(data[lIdx+1 : rIdx])

--- a/sigar_linux_test.go
+++ b/sigar_linux_test.go
@@ -40,6 +40,9 @@ func TestLinuxProcState(t *testing.T) {
 	var procNames = []string{
 		"cron",
 		"a very long process name",
+		"(sd-pam)",
+		"]",
+		"(",
 	}
 
 	for _, n := range procNames {
@@ -66,9 +69,18 @@ func TestLinuxProcState(t *testing.T) {
 
 			state := sigar.ProcState{}
 			if assert.NoError(t, state.Get(pid)) {
-				assert.Equal(t, n, state.Name)
-				assert.Equal(t, 2, state.Pgid)
-				assert.Equal(t, strconv.Itoa(uid), state.Username)
+				expected := sigar.ProcState{
+					Name:      n,
+					Username:  strconv.Itoa(uid),
+					State:     'S',
+					Ppid:      1,
+					Pgid:      2,
+					Tty:       4,
+					Priority:  15,
+					Nice:      16,
+					Processor: 36,
+				}
+				assert.Equal(t, expected, state)
 			}
 		}()
 	}
@@ -539,7 +551,7 @@ func writeFDs(pid int, count int) error {
 }
 
 func writePidStats(pid int, procName string, path string) error {
-	stats := "S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 " +
+	stats := "S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 " +
 		"20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 " +
 		"35 36 37 38 39"
 


### PR DESCRIPTION
- Refactor the ProcState code that parses /proc/[PID]/stat to allow any characters between the opening and closing parentheses of the comm field.
- This also improves the error handling in ProcState.Get. Previously errors from `strconv.Atio` were not checked.
- Improved the test for ProcState to validate all fields.
- Fix bug in test code that generates fake /proc/pid/stat data. It skipped "19" causing an off by one issue.

Fixes #81