### PR TITLE
add process stubs for unsupported OSes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Added method stubs for process handling for operating system that are not supported
+  by gosigar. All methods return `ErrNotImplemented` on such systems. #88
 
 ### Changed
 

--- a/sigar_stub.go
+++ b/sigar_stub.go
@@ -33,3 +33,35 @@ func (p *ProcTime) Get(int) error {
 func (self *FileSystemUsage) Get(path string) error {
 	return ErrNotImplemented{runtime.GOOS}
 }
+
+func (self *CpuList) Get() error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
+func (p *ProcState) Get(int) error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
+func (p *ProcExe) Get(int) error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
+func (p *ProcMem) Get(int) error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
+func (p *ProcFDUsage) Get(int) error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
+func (p *ProcEnv) Get(int) error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
+func (p *ProcList) Get() error {
+	return ErrNotImplemented{runtime.GOOS}
+}
+
+func (p *ProcArgs) Get(int) error {
+	return ErrNotImplemented{runtime.GOOS}
+}


### PR DESCRIPTION
From now on
 * `CpuList`
 * `ProcState`
 * `ProcExe`
 * `ProcMem`
 * `ProcFDUsage`
 * `ProcEnv`
 * `ProcList`
 * `ProcArgs`

can be called from source files not protected by conditional builds in Beats. 

This is required by https://github.com/elastic/beats/pull/5545