### PR TITLE
Use the common version of Get(pid)

### DIFF
--- a/sigar_freebsd.go
+++ b/sigar_freebsd.go
@@ -4,7 +4,6 @@ package gosigar
 
 import (
 	"io/ioutil"
-	"runtime"
 	"strconv"
 	"strings"
 	"unsafe"
@@ -106,8 +105,4 @@ func parseCpuStat(self *Cpu, line string) error {
 	self.Sys, _ = strtoull(fields[3])
 	self.Idle, _ = strtoull(fields[4])
 	return nil
-}
-
-func (self *ProcTime) Get(pid int) error {
-	return ErrNotImplemented{runtime.GOOS}
 }


### PR DESCRIPTION
This should not have been added because the common implementation is used.