### PR TITLE
Add missing error checks and file handle closes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   by gosigar. All methods return `ErrNotImplemented` on such systems. #88
 
 ### Changed
+- Fixed issues in cgroup package by adding missing error checks and closing
+  file handles. #92
 
 ### Deprecated
 

--- a/cgroup/blkio.go
+++ b/cgroup/blkio.go
@@ -246,7 +246,7 @@ func readBlkioValues(path ...string) ([]blkioValue, error) {
 		values = append(values, v)
 	}
 
-	return values, nil
+	return values, sc.Err()
 }
 
 func isColonOrSpace(r rune) bool {

--- a/cgroup/cpu.go
+++ b/cgroup/cpu.go
@@ -100,7 +100,7 @@ func cpuStat(path string, cpu *CPUSubsystem) error {
 		}
 	}
 
-	return nil
+	return sc.Err()
 }
 
 func cpuCFS(path string, cpu *CPUSubsystem) error {

--- a/cgroup/cpuacct.go
+++ b/cgroup/cpuacct.go
@@ -70,7 +70,7 @@ func cpuacctStat(path string, cpuacct *CPUAccountingSubsystem) error {
 		}
 	}
 
-	return nil
+	return sc.Err()
 }
 
 func cpuacctUsage(path string, cpuacct *CPUAccountingSubsystem) error {

--- a/cgroup/memory.go
+++ b/cgroup/memory.go
@@ -164,5 +164,5 @@ func memoryStats(path string, mem *MemorySubsystem) error {
 		}
 	}
 
-	return nil
+	return sc.Err()
 }

--- a/cgroup/util.go
+++ b/cgroup/util.go
@@ -130,6 +130,7 @@ func SupportedSubsystems(rootfsMountpoint string) (map[string]struct{}, error) {
 		}
 		return nil, err
 	}
+	defer cgroups.Close()
 
 	subsystemSet := map[string]struct{}{}
 	sc := bufio.NewScanner(cgroups)
@@ -163,7 +164,7 @@ func SupportedSubsystems(rootfsMountpoint string) (map[string]struct{}, error) {
 		subsystemSet[subsystem] = struct{}{}
 	}
 
-	return subsystemSet, nil
+	return subsystemSet, sc.Err()
 }
 
 // SubsystemMountpoints returns the mountpoints for each of the given subsystems.
@@ -178,6 +179,7 @@ func SubsystemMountpoints(rootfsMountpoint string, subsystems map[string]struct{
 	if err != nil {
 		return nil, err
 	}
+	defer mountinfo.Close()
 
 	mounts := map[string]string{}
 	sc := bufio.NewScanner(mountinfo)
@@ -220,7 +222,7 @@ func SubsystemMountpoints(rootfsMountpoint string, subsystems map[string]struct{
 		}
 	}
 
-	return mounts, nil
+	return mounts, sc.Err()
 }
 
 // ProcessCgroupPaths returns the cgroups to which a process belongs and the
@@ -234,6 +236,7 @@ func ProcessCgroupPaths(rootfsMountpoint string, pid int) (map[string]string, er
 	if err != nil {
 		return nil, err
 	}
+	defer cgroup.Close()
 
 	paths := map[string]string{}
 	sc := bufio.NewScanner(cgroup)
@@ -256,5 +259,5 @@ func ProcessCgroupPaths(rootfsMountpoint string, pid int) (map[string]string, er
 		}
 	}
 
-	return paths, nil
+	return paths, sc.Err()
 }


### PR DESCRIPTION
While reviewing this code I noticed some missing EOF error checks in the bufio.Scanner usage as well as a few missing Close() calls on file handles.