### PR TITLE
Add getrusage for Unix and partially for Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Added partial `getrusage` support for Windows to retrieve system CPU time and user CPU time. #95
+- Added full `getrusage` support for Unix. #95
 
 ### Fixed
 

--- a/concrete_sigar.go
+++ b/concrete_sigar.go
@@ -73,3 +73,11 @@ func (c *ConcreteSigar) GetFDUsage() (FDUsage, error) {
 	err := fd.Get()
 	return fd, err
 }
+
+// GetRusage return the resource usage of the process
+// Possible params: 0 = RUSAGE_SELF, 1 = RUSAGE_CHILDREN, 2 = RUSAGE_THREAD
+func (c *ConcreteSigar) GetRusage(who int) (Rusage, error) {
+	r := Rusage{}
+	err := r.Get(who)
+	return r, err
+}

--- a/concrete_sigar_test.go
+++ b/concrete_sigar_test.go
@@ -85,3 +85,13 @@ func TestConcreteGetFDUsage(t *testing.T) {
 		assert.True(t, fdUsage.Open <= fdUsage.Max)
 	}
 }
+
+func TestConcreteGetRusage(t *testing.T) {
+	concreteSigar := &sigar.ConcreteSigar{}
+	resourceUsage, err := concreteSigar.GetRusage(0)
+	skipNotImplemented(t, err, "netbsd", "solaris")
+	if assert.NoError(t, err) {
+		assert.True(t, resourceUsage.Utime >= 0)
+		assert.True(t, resourceUsage.Stime >= 0)
+	}
+}

--- a/sigar_interface.go
+++ b/sigar_interface.go
@@ -28,6 +28,7 @@ type Sigar interface {
 	GetSwap() (Swap, error)
 	GetFileSystemUsage(string) (FileSystemUsage, error)
 	GetFDUsage() (FDUsage, error)
+	GetRusage(who int) (Rusage, error)
 }
 
 type Cpu struct {
@@ -174,4 +175,23 @@ type ProcFDUsage struct {
 	Open      uint64
 	SoftLimit uint64
 	HardLimit uint64
+}
+
+type Rusage struct {
+	Utime    time.Duration
+	Stime    time.Duration
+	Maxrss   int64
+	Ixrss    int64
+	Idrss    int64
+	Isrss    int64
+	Minflt   int64
+	Majflt   int64
+	Nswap    int64
+	Inblock  int64
+	Oublock  int64
+	Msgsnd   int64
+	Msgrcv   int64
+	Nsignals int64
+	Nvcsw    int64
+	Nivcsw   int64
 }

--- a/sigar_stub.go
+++ b/sigar_stub.go
@@ -65,3 +65,7 @@ func (p *ProcList) Get() error {
 func (p *ProcArgs) Get(int) error {
 	return ErrNotImplemented{runtime.GOOS}
 }
+
+func (self *Rusage) Get(int) error {
+	return ErrNotImplemented{runtime.GOOS}
+}

--- a/sigar_windows.go
+++ b/sigar_windows.go
@@ -4,6 +4,7 @@ package gosigar
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -328,28 +329,37 @@ func (self *ProcMem) Get(pid int) error {
 }
 
 func (self *ProcTime) Get(pid int) error {
-	handle, err := syscall.OpenProcess(processQueryLimitedInfoAccess, false, uint32(pid))
+	cpu, err := getProcTimes(pid)
 	if err != nil {
-		return errors.Wrapf(err, "OpenProcess failed for pid=%v", pid)
-	}
-	defer syscall.CloseHandle(handle)
-
-	var CPU syscall.Rusage
-	if err := syscall.GetProcessTimes(handle, &CPU.CreationTime, &CPU.ExitTime, &CPU.KernelTime, &CPU.UserTime); err != nil {
-		return errors.Wrapf(err, "GetProcessTimes failed for pid=%v", pid)
+		return err
 	}
 
 	// Windows epoch times are expressed as time elapsed since midnight on
 	// January 1, 1601 at Greenwich, England. This converts the Filetime to
 	// unix epoch in milliseconds.
-	self.StartTime = uint64(CPU.CreationTime.Nanoseconds() / 1e6)
+	self.StartTime = uint64(cpu.CreationTime.Nanoseconds() / 1e6)
 
 	// Convert to millis.
-	self.User = uint64(windows.FiletimeToDuration(&CPU.UserTime).Nanoseconds() / 1e6)
-	self.Sys = uint64(windows.FiletimeToDuration(&CPU.KernelTime).Nanoseconds() / 1e6)
+	self.User = uint64(windows.FiletimeToDuration(&cpu.UserTime).Nanoseconds() / 1e6)
+	self.Sys = uint64(windows.FiletimeToDuration(&cpu.KernelTime).Nanoseconds() / 1e6)
 	self.Total = self.User + self.Sys
 
 	return nil
+}
+
+func getProcTimes(pid int) (*syscall.Rusage, error) {
+	handle, err := syscall.OpenProcess(processQueryLimitedInfoAccess, false, uint32(pid))
+	if err != nil {
+		return nil, errors.Wrapf(err, "OpenProcess failed for pid=%v", pid)
+	}
+	defer syscall.CloseHandle(handle)
+
+	var cpu syscall.Rusage
+	if err := syscall.GetProcessTimes(handle, &cpu.CreationTime, &cpu.ExitTime, &cpu.KernelTime, &cpu.UserTime); err != nil {
+		return nil, errors.Wrapf(err, "GetProcessTimes failed for pid=%v", pid)
+	}
+
+	return &cpu, nil
 }
 
 func (self *ProcArgs) Get(pid int) error {
@@ -407,4 +417,21 @@ func getWin32OperatingSystem() (Win32_OperatingSystem, error) {
 		return Win32_OperatingSystem{}, errors.New("wmi query for Win32_OperatingSystem failed")
 	}
 	return dst[0], nil
+}
+
+func (self *Rusage) Get(who int) error {
+	if who != 0 {
+		return ErrNotImplemented{runtime.GOOS}
+	}
+
+	pid := os.Getpid()
+	cpu, err := getProcTimes(pid)
+	if err != nil {
+		return err
+	}
+
+	self.Utime = windows.FiletimeToDuration(&cpu.UserTime)
+	self.Stime = windows.FiletimeToDuration(&cpu.KernelTime)
+
+	return nil
 }


### PR DESCRIPTION
To retrieve CPU usage time in millis in Beats, `getrusage` is added.
On Unix it is fully supported. On Windows only system and user time retrieval is implemented.