### PR TITLE
Recover as workaround for panic when reading proc files

### DIFF
--- a/sigar_linux_common.go
+++ b/sigar_linux_common.go
@@ -424,8 +424,18 @@ func procFileName(pid int, name string) string {
 	return Procd + "/" + strconv.Itoa(pid) + "/" + name
 }
 
-func readProcFile(pid int, name string) ([]byte, error) {
+func readProcFile(pid int, name string) (content []byte, err error) {
 	path := procFileName(pid, name)
+
+	// Panics have been reported when reading proc files, let's recover and
+	// report the path if this happens
+	// See https://github.com/elastic/beats/issues/6692
+	defer func() {
+		if r := recover(); r != nil {
+			content = nil
+			err = fmt.Errorf("recovered panic when reading proc file '%s': %v", path, r)
+		}
+	}()
 	contents, err := ioutil.ReadFile(path)
 
 	if err != nil {


### PR DESCRIPTION
Panics have been reported when reading from proc files, this shouldn't happen, but while root cause is found we can workaround the issue recovering from the panic and reporting the specific procfile whose
read provoked the panic.

See https://github.com/elastic/beats/issues/6692