### PR TITLE
Test with newer Go versions in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ os:
   - osx
 
 go:
-  - 1.8.3
+  - 1.8.x
+  - 1.10.x
 
 env:
   global:


### PR DESCRIPTION
Test gosigar with latest 1.8 (to keep compatibility with this version) and 1.10 versions.