### PR TITLE
Command line can be nil in Win32_Process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Added missing runtime import for FreeBSD. #104
+- Handle nil command line in Windows processes. #110
 
 ### Changed
 

--- a/sigar_windows.go
+++ b/sigar_windows.go
@@ -22,7 +22,7 @@ import (
 // automatically be populated when calling getWin32Process.
 // https://msdn.microsoft.com/en-us/library/windows/desktop/aa394372(v=vs.85).aspx
 type Win32_Process struct {
-	CommandLine string
+	CommandLine *string
 }
 
 // Win32_OperatingSystem WMI class represents a Windows-based operating system
@@ -376,8 +376,10 @@ func (self *ProcArgs) Get(pid int) error {
 	if err != nil {
 		return errors.Wrapf(err, "ProcArgs failed for pid=%v", pid)
 	}
+	if process.CommandLine != nil {
+		self.List = []string{*process.CommandLine}
+	}
 
-	self.List = []string{process.CommandLine}
 	return nil
 }
 


### PR DESCRIPTION
Command line can be nil, what produces errors like:
```
wmi: cannot load field "CommandLine" into a "string": unsupported type (<nil>)`
```
Change command line in receiving struct to be a pointer, so it can be converted by `wmi` if it receives a `nil`.