### PR TITLE
Use volume iterators to list volumes in windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added missing runtime import for FreeBSD. #104
 - Handle nil command line in Windows processes. #110
+- List filesystems on Windows that have an access path but not an assigned letter. #112
 
 ### Changed
 

--- a/examples/df/df.go
+++ b/examples/df/df.go
@@ -13,7 +13,11 @@ const output_format = "%-15s %4s %4s %5s %4s %-15s\n"
 
 func main() {
 	fslist := gosigar.FileSystemList{}
-	fslist.Get()
+	err := fslist.Get()
+	if err != nil {
+		fmt.Printf("Failed to get list of filesystems: %v", err)
+		os.Exit(-1)
+	}
 
 	fmt.Fprintf(os.Stdout, output_format,
 		"Filesystem", "Size", "Used", "Avail", "Use%", "Mounted on")

--- a/sigar_windows.go
+++ b/sigar_windows.go
@@ -155,9 +155,9 @@ func (self *CpuList) Get() error {
 }
 
 func (self *FileSystemList) Get() error {
-	drives, err := windows.GetLogicalDriveStrings()
+	drives, err := windows.GetMountedVolumes()
 	if err != nil {
-		return errors.Wrap(err, "GetLogicalDriveStrings failed")
+		return errors.Wrap(err, "GetMountedVolumes failed")
 	}
 
 	for _, drive := range drives {

--- a/sigar_windows.go
+++ b/sigar_windows.go
@@ -155,9 +155,9 @@ func (self *CpuList) Get() error {
 }
 
 func (self *FileSystemList) Get() error {
-	drives, err := windows.GetMountedVolumes()
+	drives, err := windows.GetAccessPaths()
 	if err != nil {
-		return errors.Wrap(err, "GetMountedVolumes failed")
+		return errors.Wrap(err, "GetAccessPaths failed")
 	}
 
 	for _, drive := range drives {

--- a/sys/windows/syscall_windows.go
+++ b/sys/windows/syscall_windows.go
@@ -178,7 +178,7 @@ func GetAccessPaths() ([]string, error) {
 	return paths, nil
 }
 
-// GetVolumes returs the list of volumes in the system
+// GetVolumes returs the list of volumes in the system.
 // https://docs.microsoft.com/es-es/windows/desktop/api/fileapi/nf-fileapi-findfirstvolumew
 func GetVolumes() ([]string, error) {
 	buffer := make([]uint16, MAX_PATH+1)
@@ -206,7 +206,7 @@ func GetVolumes() ([]string, error) {
 	return volumes, nil
 }
 
-// GetVolumePathsForVolume returns the list of volume paths for a volume
+// GetVolumePathsForVolume returns the list of volume paths for a volume.
 // https://docs.microsoft.com/en-us/windows/desktop/api/FileAPI/nf-fileapi-getvolumepathnamesforvolumenamew
 func GetVolumePathsForVolume(volumeName string) ([]string, error) {
 	var length uint32
@@ -216,7 +216,7 @@ func GetVolumePathsForVolume(volumeName string) ([]string, error) {
 	}
 	if length == 0 {
 		// Not mounted, no paths, that's ok
-		return []string{}, nil
+		return nil, nil
 	}
 
 	buffer := make([]uint16, length*(MAX_PATH+1))
@@ -463,7 +463,7 @@ func UTF16SliceToStringSlice(buffer []uint16) []string {
 //sys   _LookupPrivilegeName(systemName string, luid *int64, buffer *uint16, size *uint32) (err error) = advapi32.LookupPrivilegeNameW
 //sys   _LookupPrivilegeValue(systemName string, name string, luid *int64) (err error) = advapi32.LookupPrivilegeValueW
 //sys   _AdjustTokenPrivileges(token syscall.Token, releaseAll bool, input *byte, outputSize uint32, output *byte, requiredSize *uint32) (success bool, err error) [true] = advapi32.AdjustTokenPrivileges
-//sys  _FindFirstVolume(volumeName *uint16, size uint32) (handle syscall.Handle, err error) = kernel32.FindFirstVolumeW
-//sys _FindNextVolume(handle syscall.Handle, volumeName *uint16, size uint32) (err error) = kernel32.FindNextVolumeW
-//sys _FindVolumeClose(handle syscall.Handle) (err error) = kernel32.FindVolumeClose
-//sys _GetVolumePathNamesForVolumeName(volumeName string, buffer *uint16, bufferSize uint32, length *uint32) (err error) = kernel32.GetVolumePathNamesForVolumeNameW
+//sys   _FindFirstVolume(volumeName *uint16, size uint32) (handle syscall.Handle, err error) = kernel32.FindFirstVolumeW
+//sys  _FindNextVolume(handle syscall.Handle, volumeName *uint16, size uint32) (err error) = kernel32.FindNextVolumeW
+//sys  _FindVolumeClose(handle syscall.Handle) (err error) = kernel32.FindVolumeClose
+//sys  _GetVolumePathNamesForVolumeName(volumeName string, buffer *uint16, bufferSize uint32, length *uint32) (err error) = kernel32.GetVolumePathNamesForVolumeNameW

--- a/sys/windows/syscall_windows.go
+++ b/sys/windows/syscall_windows.go
@@ -181,7 +181,7 @@ func GetAccessPaths() ([]string, error) {
 // GetVolumes returs the list of volumes in the system
 // https://docs.microsoft.com/es-es/windows/desktop/api/fileapi/nf-fileapi-findfirstvolumew
 func GetVolumes() ([]string, error) {
-	buffer := make([]uint16, MAX_PATH)
+	buffer := make([]uint16, MAX_PATH+1)
 
 	var volumes []string
 

--- a/sys/windows/syscall_windows.go
+++ b/sys/windows/syscall_windows.go
@@ -444,7 +444,7 @@ func UTF16SliceToStringSlice(buffer []uint16) []string {
 // Use "GOOS=windows go generate -v -x ." to generate the source.
 
 // Add -trace to enable debug prints around syscalls.
-//go:generate go run $GOROOT/src/syscall/mksyscall_windows.go -output zsyscall_windows.go syscall_windows.go
+//go:generate go run $GOROOT/src/syscall/mksyscall_windows.go -systemdll=false -output zsyscall_windows.go syscall_windows.go
 
 // Windows API calls
 //sys   _GlobalMemoryStatusEx(buffer *MemoryStatusEx) (err error) = kernel32.GlobalMemoryStatusEx

--- a/sys/windows/zsyscall_windows.go
+++ b/sys/windows/zsyscall_windows.go
@@ -60,7 +60,6 @@ var (
 	procFindNextVolumeW                  = modkernel32.NewProc("FindNextVolumeW")
 	procFindVolumeClose                  = modkernel32.NewProc("FindVolumeClose")
 	procGetVolumePathNamesForVolumeNameW = modkernel32.NewProc("GetVolumePathNamesForVolumeNameW")
-	procQueryDosDeviceW                  = modkernel32.NewProc("QueryDosDeviceW")
 )
 
 func _GlobalMemoryStatusEx(buffer *MemoryStatusEx) (err error) {
@@ -339,27 +338,6 @@ func _GetVolumePathNamesForVolumeName(volumeName string, buffer *uint16, bufferS
 
 func __GetVolumePathNamesForVolumeName(volumeName *uint16, buffer *uint16, bufferSize uint32, length *uint32) (err error) {
 	r1, _, e1 := syscall.Syscall6(procGetVolumePathNamesForVolumeNameW.Addr(), 4, uintptr(unsafe.Pointer(volumeName)), uintptr(unsafe.Pointer(buffer)), uintptr(bufferSize), uintptr(unsafe.Pointer(length)), 0, 0)
-	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
-	return
-}
-
-func _QueryDosDevice(volumeName string, deviceName *uint16, size uint32) (err error) {
-	var _p0 *uint16
-	_p0, err = syscall.UTF16PtrFromString(volumeName)
-	if err != nil {
-		return
-	}
-	return __QueryDosDevice(_p0, deviceName, size)
-}
-
-func __QueryDosDevice(volumeName *uint16, deviceName *uint16, size uint32) (err error) {
-	r1, _, e1 := syscall.Syscall(procQueryDosDeviceW.Addr(), 3, uintptr(unsafe.Pointer(volumeName)), uintptr(unsafe.Pointer(deviceName)), uintptr(size))
 	if r1 == 0 {
 		if e1 != 0 {
 			err = errnoErr(e1)

--- a/sys/windows/zsyscall_windows.go
+++ b/sys/windows/zsyscall_windows.go
@@ -2,10 +2,37 @@
 
 package windows
 
-import "unsafe"
-import "syscall"
+import (
+	"syscall"
+	"unsafe"
+)
 
 var _ unsafe.Pointer
+
+// Do the interface allocations only once for common
+// Errno values.
+const (
+	errnoERROR_IO_PENDING = 997
+)
+
+var (
+	errERROR_IO_PENDING error = syscall.Errno(errnoERROR_IO_PENDING)
+)
+
+// errnoErr returns common boxed Errno values, to prevent
+// allocations at runtime.
+func errnoErr(e syscall.Errno) error {
+	switch e {
+	case 0:
+		return nil
+	case errnoERROR_IO_PENDING:
+		return errERROR_IO_PENDING
+	}
+	// TODO: add more here, after collecting data on the common
+	// error values see on Windows. (perhaps when running
+	// all.bat?)
+	return e
+}
 
 var (
 	modkernel32 = syscall.NewLazyDLL("kernel32.dll")
@@ -13,29 +40,34 @@ var (
 	modntdll    = syscall.NewLazyDLL("ntdll.dll")
 	modadvapi32 = syscall.NewLazyDLL("advapi32.dll")
 
-	procGlobalMemoryStatusEx      = modkernel32.NewProc("GlobalMemoryStatusEx")
-	procGetLogicalDriveStringsW   = modkernel32.NewProc("GetLogicalDriveStringsW")
-	procGetProcessMemoryInfo      = modpsapi.NewProc("GetProcessMemoryInfo")
-	procGetProcessImageFileNameW  = modpsapi.NewProc("GetProcessImageFileNameW")
-	procGetSystemTimes            = modkernel32.NewProc("GetSystemTimes")
-	procGetDriveTypeW             = modkernel32.NewProc("GetDriveTypeW")
-	procEnumProcesses             = modpsapi.NewProc("EnumProcesses")
-	procGetDiskFreeSpaceExW       = modkernel32.NewProc("GetDiskFreeSpaceExW")
-	procProcess32FirstW           = modkernel32.NewProc("Process32FirstW")
-	procProcess32NextW            = modkernel32.NewProc("Process32NextW")
-	procCreateToolhelp32Snapshot  = modkernel32.NewProc("CreateToolhelp32Snapshot")
-	procNtQuerySystemInformation  = modntdll.NewProc("NtQuerySystemInformation")
-	procNtQueryInformationProcess = modntdll.NewProc("NtQueryInformationProcess")
-	procLookupPrivilegeNameW      = modadvapi32.NewProc("LookupPrivilegeNameW")
-	procLookupPrivilegeValueW     = modadvapi32.NewProc("LookupPrivilegeValueW")
-	procAdjustTokenPrivileges     = modadvapi32.NewProc("AdjustTokenPrivileges")
+	procGlobalMemoryStatusEx             = modkernel32.NewProc("GlobalMemoryStatusEx")
+	procGetLogicalDriveStringsW          = modkernel32.NewProc("GetLogicalDriveStringsW")
+	procGetProcessMemoryInfo             = modpsapi.NewProc("GetProcessMemoryInfo")
+	procGetProcessImageFileNameW         = modpsapi.NewProc("GetProcessImageFileNameW")
+	procGetSystemTimes                   = modkernel32.NewProc("GetSystemTimes")
+	procGetDriveTypeW                    = modkernel32.NewProc("GetDriveTypeW")
+	procEnumProcesses                    = modpsapi.NewProc("EnumProcesses")
+	procGetDiskFreeSpaceExW              = modkernel32.NewProc("GetDiskFreeSpaceExW")
+	procProcess32FirstW                  = modkernel32.NewProc("Process32FirstW")
+	procProcess32NextW                   = modkernel32.NewProc("Process32NextW")
+	procCreateToolhelp32Snapshot         = modkernel32.NewProc("CreateToolhelp32Snapshot")
+	procNtQuerySystemInformation         = modntdll.NewProc("NtQuerySystemInformation")
+	procNtQueryInformationProcess        = modntdll.NewProc("NtQueryInformationProcess")
+	procLookupPrivilegeNameW             = modadvapi32.NewProc("LookupPrivilegeNameW")
+	procLookupPrivilegeValueW            = modadvapi32.NewProc("LookupPrivilegeValueW")
+	procAdjustTokenPrivileges            = modadvapi32.NewProc("AdjustTokenPrivileges")
+	procFindFirstVolumeW                 = modkernel32.NewProc("FindFirstVolumeW")
+	procFindNextVolumeW                  = modkernel32.NewProc("FindNextVolumeW")
+	procFindVolumeClose                  = modkernel32.NewProc("FindVolumeClose")
+	procGetVolumePathNamesForVolumeNameW = modkernel32.NewProc("GetVolumePathNamesForVolumeNameW")
+	procQueryDosDeviceW                  = modkernel32.NewProc("QueryDosDeviceW")
 )
 
 func _GlobalMemoryStatusEx(buffer *MemoryStatusEx) (err error) {
 	r1, _, e1 := syscall.Syscall(procGlobalMemoryStatusEx.Addr(), 1, uintptr(unsafe.Pointer(buffer)), 0, 0)
 	if r1 == 0 {
 		if e1 != 0 {
-			err = error(e1)
+			err = errnoErr(e1)
 		} else {
 			err = syscall.EINVAL
 		}
@@ -48,7 +80,7 @@ func _GetLogicalDriveStringsW(bufferLength uint32, buffer *uint16) (length uint3
 	length = uint32(r0)
 	if length == 0 {
 		if e1 != 0 {
-			err = error(e1)
+			err = errnoErr(e1)
 		} else {
 			err = syscall.EINVAL
 		}
@@ -60,7 +92,7 @@ func _GetProcessMemoryInfo(handle syscall.Handle, psmemCounters *ProcessMemoryCo
 	r1, _, e1 := syscall.Syscall(procGetProcessMemoryInfo.Addr(), 3, uintptr(handle), uintptr(unsafe.Pointer(psmemCounters)), uintptr(cb))
 	if r1 == 0 {
 		if e1 != 0 {
-			err = error(e1)
+			err = errnoErr(e1)
 		} else {
 			err = syscall.EINVAL
 		}
@@ -73,7 +105,7 @@ func _GetProcessImageFileName(handle syscall.Handle, outImageFileName *uint16, s
 	length = uint32(r0)
 	if length == 0 {
 		if e1 != 0 {
-			err = error(e1)
+			err = errnoErr(e1)
 		} else {
 			err = syscall.EINVAL
 		}
@@ -85,7 +117,7 @@ func _GetSystemTimes(idleTime *syscall.Filetime, kernelTime *syscall.Filetime, u
 	r1, _, e1 := syscall.Syscall(procGetSystemTimes.Addr(), 3, uintptr(unsafe.Pointer(idleTime)), uintptr(unsafe.Pointer(kernelTime)), uintptr(unsafe.Pointer(userTime)))
 	if r1 == 0 {
 		if e1 != 0 {
-			err = error(e1)
+			err = errnoErr(e1)
 		} else {
 			err = syscall.EINVAL
 		}
@@ -98,7 +130,7 @@ func _GetDriveType(rootPathName *uint16) (dt DriveType, err error) {
 	dt = DriveType(r0)
 	if dt == 0 {
 		if e1 != 0 {
-			err = error(e1)
+			err = errnoErr(e1)
 		} else {
 			err = syscall.EINVAL
 		}
@@ -110,7 +142,7 @@ func _EnumProcesses(processIds *uint32, sizeBytes uint32, bytesReturned *uint32)
 	r1, _, e1 := syscall.Syscall(procEnumProcesses.Addr(), 3, uintptr(unsafe.Pointer(processIds)), uintptr(sizeBytes), uintptr(unsafe.Pointer(bytesReturned)))
 	if r1 == 0 {
 		if e1 != 0 {
-			err = error(e1)
+			err = errnoErr(e1)
 		} else {
 			err = syscall.EINVAL
 		}
@@ -122,7 +154,7 @@ func _GetDiskFreeSpaceEx(directoryName *uint16, freeBytesAvailable *uint64, tota
 	r1, _, e1 := syscall.Syscall6(procGetDiskFreeSpaceExW.Addr(), 4, uintptr(unsafe.Pointer(directoryName)), uintptr(unsafe.Pointer(freeBytesAvailable)), uintptr(unsafe.Pointer(totalNumberOfBytes)), uintptr(unsafe.Pointer(totalNumberOfFreeBytes)), 0, 0)
 	if r1 == 0 {
 		if e1 != 0 {
-			err = error(e1)
+			err = errnoErr(e1)
 		} else {
 			err = syscall.EINVAL
 		}
@@ -134,7 +166,7 @@ func _Process32First(handle syscall.Handle, processEntry32 *ProcessEntry32) (err
 	r1, _, e1 := syscall.Syscall(procProcess32FirstW.Addr(), 2, uintptr(handle), uintptr(unsafe.Pointer(processEntry32)), 0)
 	if r1 == 0 {
 		if e1 != 0 {
-			err = error(e1)
+			err = errnoErr(e1)
 		} else {
 			err = syscall.EINVAL
 		}
@@ -146,7 +178,7 @@ func _Process32Next(handle syscall.Handle, processEntry32 *ProcessEntry32) (err 
 	r1, _, e1 := syscall.Syscall(procProcess32NextW.Addr(), 2, uintptr(handle), uintptr(unsafe.Pointer(processEntry32)), 0)
 	if r1 == 0 {
 		if e1 != 0 {
-			err = error(e1)
+			err = errnoErr(e1)
 		} else {
 			err = syscall.EINVAL
 		}
@@ -159,7 +191,7 @@ func _CreateToolhelp32Snapshot(flags uint32, processID uint32) (handle syscall.H
 	handle = syscall.Handle(r0)
 	if handle == 0 {
 		if e1 != 0 {
-			err = error(e1)
+			err = errnoErr(e1)
 		} else {
 			err = syscall.EINVAL
 		}
@@ -172,7 +204,7 @@ func _NtQuerySystemInformation(systemInformationClass uint32, systemInformation 
 	ntstatus = uint32(r0)
 	if ntstatus == 0 {
 		if e1 != 0 {
-			err = error(e1)
+			err = errnoErr(e1)
 		} else {
 			err = syscall.EINVAL
 		}
@@ -185,7 +217,7 @@ func _NtQueryInformationProcess(processHandle syscall.Handle, processInformation
 	ntstatus = uint32(r0)
 	if ntstatus == 0 {
 		if e1 != 0 {
-			err = error(e1)
+			err = errnoErr(e1)
 		} else {
 			err = syscall.EINVAL
 		}
@@ -206,7 +238,7 @@ func __LookupPrivilegeName(systemName *uint16, luid *int64, buffer *uint16, size
 	r1, _, e1 := syscall.Syscall6(procLookupPrivilegeNameW.Addr(), 4, uintptr(unsafe.Pointer(systemName)), uintptr(unsafe.Pointer(luid)), uintptr(unsafe.Pointer(buffer)), uintptr(unsafe.Pointer(size)), 0, 0)
 	if r1 == 0 {
 		if e1 != 0 {
-			err = error(e1)
+			err = errnoErr(e1)
 		} else {
 			err = syscall.EINVAL
 		}
@@ -232,7 +264,7 @@ func __LookupPrivilegeValue(systemName *uint16, name *uint16, luid *int64) (err 
 	r1, _, e1 := syscall.Syscall(procLookupPrivilegeValueW.Addr(), 3, uintptr(unsafe.Pointer(systemName)), uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(luid)))
 	if r1 == 0 {
 		if e1 != 0 {
-			err = error(e1)
+			err = errnoErr(e1)
 		} else {
 			err = syscall.EINVAL
 		}
@@ -251,7 +283,86 @@ func _AdjustTokenPrivileges(token syscall.Token, releaseAll bool, input *byte, o
 	success = r0 != 0
 	if true {
 		if e1 != 0 {
-			err = error(e1)
+			err = errnoErr(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func _FindFirstVolume(volumeName *uint16, size uint32) (handle syscall.Handle, err error) {
+	r0, _, e1 := syscall.Syscall(procFindFirstVolumeW.Addr(), 2, uintptr(unsafe.Pointer(volumeName)), uintptr(size), 0)
+	handle = syscall.Handle(r0)
+	if handle == 0 {
+		if e1 != 0 {
+			err = errnoErr(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func _FindNextVolume(handle syscall.Handle, volumeName *uint16, size uint32) (err error) {
+	r1, _, e1 := syscall.Syscall(procFindNextVolumeW.Addr(), 3, uintptr(handle), uintptr(unsafe.Pointer(volumeName)), uintptr(size))
+	if r1 == 0 {
+		if e1 != 0 {
+			err = errnoErr(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func _FindVolumeClose(handle syscall.Handle) (err error) {
+	r1, _, e1 := syscall.Syscall(procFindVolumeClose.Addr(), 1, uintptr(handle), 0, 0)
+	if r1 == 0 {
+		if e1 != 0 {
+			err = errnoErr(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func _GetVolumePathNamesForVolumeName(volumeName string, buffer *uint16, bufferSize uint32, length *uint32) (err error) {
+	var _p0 *uint16
+	_p0, err = syscall.UTF16PtrFromString(volumeName)
+	if err != nil {
+		return
+	}
+	return __GetVolumePathNamesForVolumeName(_p0, buffer, bufferSize, length)
+}
+
+func __GetVolumePathNamesForVolumeName(volumeName *uint16, buffer *uint16, bufferSize uint32, length *uint32) (err error) {
+	r1, _, e1 := syscall.Syscall6(procGetVolumePathNamesForVolumeNameW.Addr(), 4, uintptr(unsafe.Pointer(volumeName)), uintptr(unsafe.Pointer(buffer)), uintptr(bufferSize), uintptr(unsafe.Pointer(length)), 0, 0)
+	if r1 == 0 {
+		if e1 != 0 {
+			err = errnoErr(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func _QueryDosDevice(volumeName string, deviceName *uint16, size uint32) (err error) {
+	var _p0 *uint16
+	_p0, err = syscall.UTF16PtrFromString(volumeName)
+	if err != nil {
+		return
+	}
+	return __QueryDosDevice(_p0, deviceName, size)
+}
+
+func __QueryDosDevice(volumeName *uint16, deviceName *uint16, size uint32) (err error) {
+	r1, _, e1 := syscall.Syscall(procQueryDosDeviceW.Addr(), 3, uintptr(unsafe.Pointer(volumeName)), uintptr(unsafe.Pointer(deviceName)), uintptr(size))
+	if r1 == 0 {
+		if e1 != 0 {
+			err = errnoErr(e1)
 		} else {
 			err = syscall.EINVAL
 		}


### PR DESCRIPTION
`GetLogicalDriveStrings` doesn't list filesystems that are mounted with
access paths but don't have a drive letter. Use volume iterators to
list all volumes and obtain its access paths.

Reported on https://github.com/elastic/beats/issues/8916