### PR TITLE
Implement load averages for Windows

### DIFF
--- a/sigar_windows.go
+++ b/sigar_windows.go
@@ -55,7 +55,16 @@ func init() {
 }
 
 func (self *LoadAverage) Get() error {
-	return ErrNotImplemented{runtime.GOOS}
+	one, five, fifteen, err := windows.GetLoadAverages()
+	if err != nil {
+		return err
+	}
+
+	self.One = one
+	self.Five = five
+	self.Fifteen = fifteen
+
+	return nil
 }
 
 func (self *FDUsage) Get() error {

--- a/sys/windows/load.go
+++ b/sys/windows/load.go
@@ -40,7 +40,6 @@ func init() {
 // system. Load averages are based on processor queue lengths, which is the number of processes
 // waiting for time on the CPU. This function also samples the current load average when called.
 func GetLoadAverages() (float64, float64, float64, error) {
-
 	// Sample current load
 	currentLoad, err := getCurrentLoad()
 	if err != nil {

--- a/sys/windows/load.go
+++ b/sys/windows/load.go
@@ -1,0 +1,95 @@
+// +build windows
+
+package windows
+
+import (
+	"time"
+	"github.com/StackExchange/wmi"
+)
+
+type win32_PerfFormattedData_PerfOS_System struct {
+	ProcessorQueueLength int
+}
+
+type loadSample struct {
+	timestamp time.Time
+	value     int
+}
+
+type loadSamplesType struct {
+	samples []loadSample
+	lock    mutex.RWMutex
+}
+
+const (
+	LOAD_HISTORY_DURATION = 15 * time.Minute
+)
+
+var (
+	// loadSamples is a list of loadSamples. The list keeps samples up to
+	// LOAD_HISTORY_DURATION old.
+	loadSamples loadSamplesType
+)
+
+func init() {
+	loadSamples = loadSamplesType{}
+}
+
+// GetLoadAverages returns the 1-minute, 5-minute, and 15-minute load averages for a Windows
+// system. Load averages are based on processor queue lengths, which is the number of processes
+// waiting for time on the CPU. This function also samples the current load average when called.
+function GetLoadAverages() (float64, float64, float64, error) {
+	var dst []win32_PerfFormattedData_PerfOS_System
+	q := wmi.CreateQuery(&dst, "")
+	err := wmi.Query(q, &dst)
+	if err != nil {
+		return errors.Wrap(err, "wmi query for Win32_PerfFormattedData_PerfOS_System failed")
+	}
+	if len(dst) != 1 {
+		return errors.New("wmi query for Win32_PerfFormattedData_PerfOS_System failed")
+	}
+
+	currentLoad := dst[0].ProcessorQueueLength
+	addLoadSample(currentLoad)
+
+	one = getLoadAverage(1 * time.Duration)
+	five = getLoadAverage(5 * time.Duration)
+	fifteen = getLoadAverage(15 * time.Duration)
+
+	return one, five, fifteen, nil
+}
+
+func addLoadSample(value int) {
+	now := time.Now
+
+	loadSamples.lock.Lock()
+	defer loadSamples.lock.Unlock()
+
+	loadSamples.samples = append(loadSamples.samples, value)
+
+	// Cleanup old samples
+	newLoadSamples = []loadSample{}
+	for _, sample := range loadSamples.samples {
+		if sample.timestamp.After(now.Add(-LOAD_HISTORY_DURATION)) {
+			newLoadSamples = append(newLoadSamples, sample)
+		}
+	}
+	loadSamples.samples = newLoadSamples
+}
+
+func getAverageLoad(avergeDuration time.Duration) float64 {
+	loadSamples.lock.RLock()
+	defer loadSamples.lock.RUnlock()
+
+	total := 0
+	count := 0
+	startTime := now.Add(-avergeDuration)
+	for _, sample := range loadSamples.samples {
+		if sample.timestamp >= startTime {
+			total += sample.value
+			count++
+		}
+	}
+
+	return float64(total / count)
+}

--- a/sys/windows/load.go
+++ b/sys/windows/load.go
@@ -3,6 +3,7 @@
 package windows
 
 import (
+	"sync"
 	"time"
 
 	"github.com/StackExchange/wmi"
@@ -20,7 +21,7 @@ type loadSample struct {
 
 type loadSamplesType struct {
 	samples []loadSample
-	lock    mutex.RWMutex
+	lock    sync.RWMutex
 }
 
 const (

--- a/sys/windows/load.go
+++ b/sys/windows/load.go
@@ -89,7 +89,7 @@ func addLoadSample(value int) {
 	loadSamples.samples = newLoadSamples
 }
 
-func getAverageLoad(avergeDuration time.Duration) float64 {
+func getLoadAverage(avergeDuration time.Duration) float64 {
 	loadSamples.lock.RLock()
 	defer loadSamples.lock.RUnlock()
 

--- a/sys/windows/load.go
+++ b/sys/windows/load.go
@@ -41,6 +41,23 @@ func init() {
 // system. Load averages are based on processor queue lengths, which is the number of processes
 // waiting for time on the CPU. This function also samples the current load average when called.
 func GetLoadAverages() (float64, float64, float64, error) {
+
+	// Sample current load
+	currentLoad, err := getCurrentLoad()
+	if err != nil {
+		return err
+	}
+	addLoadSample(currentLoad)
+
+	// Calculate 1-minute, 5-minute, and 15-minute load averages
+	one = getLoadAverage(1 * time.Duration)
+	five = getLoadAverage(5 * time.Duration)
+	fifteen = getLoadAverage(15 * time.Duration)
+
+	return one, five, fifteen, nil
+}
+
+func getCurrentLoad() int, error {
 	var dst []win32_PerfFormattedData_PerfOS_System
 	q := wmi.CreateQuery(&dst, "")
 	err := wmi.Query(q, &dst)
@@ -52,13 +69,7 @@ func GetLoadAverages() (float64, float64, float64, error) {
 	}
 
 	currentLoad := dst[0].ProcessorQueueLength
-	addLoadSample(currentLoad)
-
-	one = getLoadAverage(1 * time.Duration)
-	five = getLoadAverage(5 * time.Duration)
-	fifteen = getLoadAverage(15 * time.Duration)
-
-	return one, five, fifteen, nil
+	return currentLoad
 }
 
 func addLoadSample(value int) {

--- a/sys/windows/load.go
+++ b/sys/windows/load.go
@@ -61,10 +61,10 @@ func getCurrentLoad() (int, error) {
 	q := wmi.CreateQuery(&dst, "")
 	err := wmi.Query(q, &dst)
 	if err != nil {
-		return errors.Wrap(err, "wmi query for Win32_PerfFormattedData_PerfOS_System failed")
+		return 0, errors.Wrap(err, "wmi query for Win32_PerfFormattedData_PerfOS_System failed")
 	}
 	if len(dst) != 1 {
-		return errors.New("wmi query for Win32_PerfFormattedData_PerfOS_System failed")
+		return 0, errors.New("wmi query for Win32_PerfFormattedData_PerfOS_System failed")
 	}
 
 	currentLoad := dst[0].ProcessorQueueLength

--- a/sys/windows/load.go
+++ b/sys/windows/load.go
@@ -49,9 +49,9 @@ func GetLoadAverages() (float64, float64, float64, error) {
 	addLoadSample(currentLoad)
 
 	// Calculate 1-minute, 5-minute, and 15-minute load averages
-	one := getLoadAverage(1 * time.Duration)
-	five := getLoadAverage(5 * time.Duration)
-	fifteen := getLoadAverage(15 * time.Duration)
+	one := getLoadAverage(1 * time.Minute)
+	five := getLoadAverage(5 * time.Minute)
+	fifteen := getLoadAverage(15 * time.Minute)
 
 	return one, five, fifteen, nil
 }
@@ -72,15 +72,15 @@ func getCurrentLoad() (int, error) {
 }
 
 func addLoadSample(value int) {
-	now := time.Now
+	now := time.Now()
 
 	loadSamples.lock.Lock()
 	defer loadSamples.lock.Unlock()
 
-	loadSamples.samples = append(loadSamples.samples, value)
+	loadSamples.samples = append(loadSamples.samples, loadSample{now, value})
 
 	// Cleanup old samples
-	newLoadSamples = []loadSample{}
+	newLoadSamples := []loadSample{}
 	for _, sample := range loadSamples.samples {
 		if sample.timestamp.After(now.Add(-LOAD_HISTORY_DURATION)) {
 			newLoadSamples = append(newLoadSamples, sample)

--- a/sys/windows/load.go
+++ b/sys/windows/load.go
@@ -28,8 +28,7 @@ const (
 )
 
 var (
-	// loadSamples is a list of loadSamples. The list keeps samples up to
-	// LOAD_HISTORY_DURATION old.
+	// loadSamples keeps samples up to LOAD_HISTORY_DURATION old.
 	loadSamples loadSamplesType
 )
 

--- a/sys/windows/load.go
+++ b/sys/windows/load.go
@@ -4,7 +4,9 @@ package windows
 
 import (
 	"time"
+
 	"github.com/StackExchange/wmi"
+	"github.com/pkg/errors"
 )
 
 type win32_PerfFormattedData_PerfOS_System struct {
@@ -38,7 +40,7 @@ func init() {
 // GetLoadAverages returns the 1-minute, 5-minute, and 15-minute load averages for a Windows
 // system. Load averages are based on processor queue lengths, which is the number of processes
 // waiting for time on the CPU. This function also samples the current load average when called.
-function GetLoadAverages() (float64, float64, float64, error) {
+func GetLoadAverages() (float64, float64, float64, error) {
 	var dst []win32_PerfFormattedData_PerfOS_System
 	q := wmi.CreateQuery(&dst, "")
 	err := wmi.Query(q, &dst)

--- a/sys/windows/load.go
+++ b/sys/windows/load.go
@@ -55,7 +55,7 @@ func GetLoadAverages() (float64, float64, float64, error) {
 	return one, five, fifteen, nil
 }
 
-func getCurrentLoad() int, error {
+func getCurrentLoad() (int, error) {
 	var dst []win32_PerfFormattedData_PerfOS_System
 	q := wmi.CreateQuery(&dst, "")
 	err := wmi.Query(q, &dst)

--- a/sys/windows/load.go
+++ b/sys/windows/load.go
@@ -49,9 +49,9 @@ func GetLoadAverages() (float64, float64, float64, error) {
 	addLoadSample(currentLoad)
 
 	// Calculate 1-minute, 5-minute, and 15-minute load averages
-	one = getLoadAverage(1 * time.Duration)
-	five = getLoadAverage(5 * time.Duration)
-	fifteen = getLoadAverage(15 * time.Duration)
+	one := getLoadAverage(1 * time.Duration)
+	five := getLoadAverage(5 * time.Duration)
+	fifteen := getLoadAverage(15 * time.Duration)
 
 	return one, five, fifteen, nil
 }

--- a/sys/windows/load.go
+++ b/sys/windows/load.go
@@ -44,7 +44,7 @@ func GetLoadAverages() (float64, float64, float64, error) {
 	// Sample current load
 	currentLoad, err := getCurrentLoad()
 	if err != nil {
-		return err
+		return 0, 0, 0, err
 	}
 	addLoadSample(currentLoad)
 


### PR DESCRIPTION
Resolves #114.

This PR attempts to implement this method:

https://github.com/elastic/gosigar/blob/7bed2391b1d10309feac210aee9df44e8db2d060/sigar_windows.go#L57-L59

Concretely, it does the following:

1. Whenever the above method is called, i.e. load averages for a Windows system are requested, the code actually takes a sample of the current load average. This load average is based on the length of the processor queue, which is the number of processes waiting for CPU time. It's not a perfect approximation of system load.

2. Over time, several samples get collected. Adding a new sample also does a bit of clean up to make sure we don't keep samples older than 15 minutes, which is the max. time necessary to generate the 15-minute load average.

3. The samples are used to compute the 1-minute, 10-minute, and 15-minute averages.

### Caveats

This implementation is simple but suffers from a couple of drawbacks:

1. The first few invocations of the above method will not return useful load averages, as enough samples have not yet been collected.

2. The frequency of sample collection == frequency of method invocation. So if the method is invoked very infrequently, fewer samples will be collected, leading to very imprecise load averages.

An alternative implementation could involve decoupling the sampling from the invocation of the above method. Sampling go happen on a timer in a goroutine.