### PR TITLE
Fix memory leak when calling CommandLineToArgv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fix memory leak when getting process arguments. #119
+
 ### Changed
 
 ### Deprecated

--- a/sys/windows/syscall_windows.go
+++ b/sys/windows/syscall_windows.go
@@ -526,6 +526,10 @@ func ByteSliceToStringSlice(utf16 []byte) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Free memory allocated for CommandLineToArgvW arguments.
+	defer syscall.LocalFree((syscall.Handle)(unsafe.Pointer(argsWide)))
+
 	args := make([]string, numArgs)
 	for idx := range args {
 		args[idx] = syscall.UTF16ToString(argsWide[idx][:])


### PR DESCRIPTION
It is necessary to call LocalFree() on the returned buffer to avoid leaking memory.