### PR TITLE
Windows: Do not fail ProcState.Get when run by non-admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Fixed
+- ProcState.Get() doesn't fail under Windows when it cannot obtain process ownership information. #121
 
 ### Changed
 

--- a/sigar_windows.go
+++ b/sigar_windows.go
@@ -194,6 +194,10 @@ func (self *ProcState) Get(pid int) error {
 		errs = append(errs, errors.Wrap(err, "getParentPid failed"))
 	}
 
+	// getProcCredName will often fail when run as a non-admin user. This is
+	// caused by strict ACL of the process token belonging to other users.
+	// Instead of failing completely, ignore this error and still return most
+	// data with an empty Username.
 	self.Username, _ = getProcCredName(pid)
 
 	if len(errs) > 0 {


### PR DESCRIPTION
When running under Windows as a non-administrator  user, ProcState.Get() will fail with the error "OpenProcessToken failed for pid=XXX: Permission denied".

This is a known issue under Windows: A non-admin won't be able to access the token of most processes, regardless of privileges (i.e. SeDebugPrivilege).

This PR allows ProcState.Get to return with a missing username instead of failing completely.

I also took the opportunity to fix a case where it would be leaking a handle under an error condition.