### PR TITLE
Add resource usage to support matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The features vary by operating system.
 | ProcMem         |   X   |    X   |    X    |         |    X    |
 | ProcState       |   X   |    X   |    X    |         |    X    |
 | ProcTime        |   X   |    X   |    X    |         |    X    |
+| Rusage          |   X   |        |    X    |         |         |
 | Swap            |   X   |    X   |         |    X    |    X    |
 | Uptime          |   X   |    X   |         |    X    |    X    |
 


### PR DESCRIPTION
The recent PR to add linux and Windows support for resource usage didn't add an entry to the support matrix. This adds an entry to the matrix.