### PR TITLE
Use NewLazySystemDLL instead of NewLazyDLL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Load DLLs only from Windows system directory.
+
 ### Deprecated
 
 ## [0.10.4]

--- a/sys/windows/doc.go
+++ b/sys/windows/doc.go
@@ -1,2 +1,8 @@
 // Package windows contains various Windows system call.
 package windows
+
+// Use "go generate -v -x ." to generate the source.
+
+// Add -trace to enable debug prints around syscalls.
+//go:generate go run $GOROOT/src/syscall/mksyscall_windows.go -systemdll=true -output zsyscall_windows.go syscall_windows.go
+//go:generate go run fix_generated.go -input zsyscall_windows.go

--- a/sys/windows/fix_generated.go
+++ b/sys/windows/fix_generated.go
@@ -1,0 +1,60 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//+build ignore
+
+package main
+
+import (
+	"flag"
+	"io/ioutil"
+	"log"
+	"regexp"
+)
+
+func main() {
+	var filename string
+
+	log.SetFlags(0)
+	flag.StringVar(&filename, "input", "", "name of generated source file to fix")
+	flag.Parse()
+
+	if filename == "" {
+		log.Fatal("Name of generated file must be specified with -input flag")
+	}
+
+	if err := fixGeneratedCode(filename); err != nil {
+		log.Fatal(err)
+	}
+}
+
+var lazySystemRegex = regexp.MustCompile(`(?m)\sNewLazySystemDLL`)
+var unsafeImportRegex = regexp.MustCompile(`(?m)"unsafe"`)
+
+// fixGeneratedCode adds "windows." to locations in the generated source code
+// that reference "NewLazySystemDLL" without the package name.
+func fixGeneratedCode(filename string) error {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+
+	data = lazySystemRegex.ReplaceAll(data, []byte(" windows.NewLazySystemDLL"))
+	data = unsafeImportRegex.ReplaceAll(data, []byte(`"unsafe"`+"\n\n\t"+`"golang.org/x/sys/windows"`))
+
+	return ioutil.WriteFile(filename, data, 0644)
+}

--- a/sys/windows/zsyscall_windows.go
+++ b/sys/windows/zsyscall_windows.go
@@ -5,6 +5,8 @@ package windows
 import (
 	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 var _ unsafe.Pointer
@@ -35,10 +37,10 @@ func errnoErr(e syscall.Errno) error {
 }
 
 var (
-	modkernel32 = syscall.NewLazyDLL("kernel32.dll")
-	modpsapi    = syscall.NewLazyDLL("psapi.dll")
-	modntdll    = syscall.NewLazyDLL("ntdll.dll")
-	modadvapi32 = syscall.NewLazyDLL("advapi32.dll")
+	modkernel32 = windows.NewLazySystemDLL("kernel32.dll")
+	modpsapi    = windows.NewLazySystemDLL("psapi.dll")
+	modntdll    = windows.NewLazySystemDLL("ntdll.dll")
+	modadvapi32 = windows.NewLazySystemDLL("advapi32.dll")
 
 	procGlobalMemoryStatusEx             = modkernel32.NewProc("GlobalMemoryStatusEx")
 	procGetLogicalDriveStringsW          = modkernel32.NewProc("GetLogicalDriveStringsW")


### PR DESCRIPTION
The ensures that the code only search for DLLs in the Windows system directory.