### PR TITLE
fix odd array to string function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed the `ss` example by replacing the Logrus package with the stdlib `log` package. https://github.com/elastic/gosigar/issues/123 https://github.com/elastic/gosigar/pull/136
+- Replaced `bytePtrToString` and cleaned up darwin code. https://github.com/elastic/gosigar/issues/138
 
 ### Changed
 

--- a/sigar_openbsd.go
+++ b/sigar_openbsd.go
@@ -159,9 +159,9 @@ func (self *FileSystemList) Get() error {
 	for i := 0; i < num; i++ {
 		fs := FileSystem{}
 
-		fs.DirName = bytePtrToString(&buf[i].F_mntonname[0])
-		fs.DevName = bytePtrToString(&buf[i].F_mntfromname[0])
-		fs.SysTypeName = bytePtrToString(&buf[i].F_fstypename[0])
+		fs.DirName = byteListToString(buf[i].F_mntonname[:])
+		fs.DevName = byteListToString(buf[i].F_mntfromname[:])
+		fs.SysTypeName = byteListToString(buf[i].F_fstypename[:])
 
 		fslist = append(fslist, fs)
 	}

--- a/sigar_util.go
+++ b/sigar_util.go
@@ -3,20 +3,21 @@
 package gosigar
 
 import (
-	"unsafe"
+	"bytes"
 )
 
-// TODO (2020-07-14): Fix the unsafe pointer conversion. https://github.com/elastic/gosigar/issues/138
-//go:nocheckptr
-func bytePtrToString(ptr *int8) string {
-	bytes := (*[10000]byte)(unsafe.Pointer(ptr))
+// byteListToString converts the raw byte arrays we get into a string. This is a bit of a process, as byte strings are normally []uint8
+func byteListToString(raw []int8) string {
+	byteList := make([]byte, len(raw))
 
-	n := 0
-	for bytes[n] != 0 {
-		n++
+	for pos, singleByte := range raw {
+		byteList[pos] = byte(singleByte)
+		if singleByte == 0 {
+			break
+		}
 	}
 
-	return string(bytes[0:n])
+	return string(bytes.Trim(byteList, "\x00"))
 }
 
 func chop(buf []byte) []byte {

--- a/sigar_util_test.go
+++ b/sigar_util_test.go
@@ -1,0 +1,13 @@
+package gosigar
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestByteArrayToString(t *testing.T) {
+	testIn := [16]int8{97, 112, 102, 115, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	output := byteListToString(testIn[:])
+	assert.Equal(t, "apfs", output)
+
+}


### PR DESCRIPTION
This is a perma-fix for https://github.com/elastic/gosigar/issues/138

Tested manually on Darwin. This is a really odd chunk of code I had to remove. My best guess is that whoever wrote this was more familiar with C than Golang, hence that oddball pointer logic.

Also cleaned up some of the darwin code, since it was really annoying.