### PR TITLE
Add go.mod to fix travis build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,8 @@ os: Windows Server 2012 R2
 # Environment variables
 environment:
   GOPATH: c:\gopath
-  GVM_GO_VERSION: 1.10.8
+  GO111MODULE: on
+  GVM_GO_VERSION: 1.11.13
   GVM_DL: https://github.com/andrewkroh/gvm/releases/download/v0.2.2/gvm-windows-amd64.exe
 
 # Custom clone folder (variables are not expanded here).
@@ -45,7 +46,6 @@ build_script:
   # Compile
   - appveyor AddCompilationMessage "Starting Compile"
   - cd c:\gopath\src\github.com\elastic\gosigar
-  - go get -v -t -d ./...
   - go build
   - go build -o examples/df/df.exe ./examples/df
   - go build -o examples/free/free.exe ./examples/free

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,12 @@ os:
   - osx
 
 go:
-  - 1.10.x
-  - 1.14.x
+  - 1.11.x
+  - 1.15.x
 
 env:
   global:
+    - GO111MODULE=on
     - PROJ="github.com/elastic/gosigar"
 
 sudo: false
@@ -21,10 +22,8 @@ before_install:
   - export TRAVIS_BUILD_DIR=$HOME/gopath/src/${PROJ}
   - cd $HOME/gopath/src/${PROJ}
 
-install:
-  - go get -v -t -d ./...
-
 script:
+  - go mod tidy && git diff --exit-code
   - gofmt -l . | read && echo "Code differs from gofmt's style. Run 'gofmt -w .'" 1>&2 && exit 1 || true
   - go vet
   - go build

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/elastic/gosigar
+
+go 1.14
+
+require (
+	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.4.0
+	golang.org/x/sys v0.0.0-20180810173357-98c5dad5d1a0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,15 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+golang.org/x/sys v0.0.0-20180810173357-98c5dad5d1a0 h1:8H8QZJ30plJyIVj60H3lr8TZGIq2Fh3Cyrs/ZNg1foU=
+golang.org/x/sys v0.0.0-20180810173357-98c5dad5d1a0/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Travis CI was failing while testing with Go 1.10 because the latest testify requires
Go 1.13 for error.As. So by adding go.mod to use a specific testify version (and testing
with Go 1.11 minimally since we now need 'go mod') the tests should compile.