### PR TITLE
Report cached data in Memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add AIX support. #133
+- Add `Cached` data to Memory #145
 
 ### Fixed
 

--- a/sigar_interface.go
+++ b/sigar_interface.go
@@ -82,6 +82,7 @@ type Mem struct {
 	Total      uint64
 	Used       uint64
 	Free       uint64
+	Cached     uint64
 	ActualFree uint64
 	ActualUsed uint64
 }

--- a/sigar_linux.go
+++ b/sigar_linux.go
@@ -21,6 +21,7 @@ func getMountTableFileName() string {
 	return "/etc/mtab"
 }
 
+// Get returns uptime data
 func (self *Uptime) Get() error {
 	sysinfo := syscall.Sysinfo_t{}
 
@@ -33,6 +34,7 @@ func (self *Uptime) Get() error {
 	return nil
 }
 
+// Get returns FD usage data
 func (self *FDUsage) Get() error {
 	return readFile(Procd+"/sys/fs/file-nr", func(line string) bool {
 		fields := strings.Fields(line)
@@ -45,6 +47,7 @@ func (self *FDUsage) Get() error {
 	})
 }
 
+// Get returns hugepages data
 func (self *HugeTLBPages) Get() error {
 	table, err := parseMeminfo()
 	if err != nil {
@@ -69,6 +72,7 @@ func (self *HugeTLBPages) Get() error {
 	return nil
 }
 
+// Get returns process FD usage
 func (self *ProcFDUsage) Get(pid int) error {
 	err := readFile(procFileName(pid, "limits"), func(line string) bool {
 		if strings.HasPrefix(line, "Max open files") {
@@ -107,6 +111,7 @@ func parseCpuStat(self *Cpu, line string) error {
 	return nil
 }
 
+// Get returns memory data
 func (self *Mem) Get() error {
 
 	table, err := parseMeminfo()
@@ -117,13 +122,13 @@ func (self *Mem) Get() error {
 	self.Total, _ = table["MemTotal"]
 	self.Free, _ = table["MemFree"]
 	buffers, _ := table["Buffers"]
-	cached, _ := table["Cached"]
+	self.Cached, _ = table["Cached"]
 
 	if available, ok := table["MemAvailable"]; ok {
 		// MemAvailable is in /proc/meminfo (kernel 3.14+)
 		self.ActualFree = available
 	} else {
-		self.ActualFree = self.Free + buffers + cached
+		self.ActualFree = self.Free + buffers + self.Cached
 	}
 
 	self.Used = self.Total - self.Free


### PR DESCRIPTION
See this issue for a tad more context: https://github.com/elastic/kibana/issues/77517

Right now, most front-end components that try and graph cache usage is doing it incorrectly. We're grabbing cache as a fallback to `actual` memory, so we might as well just send it along so upstream components can use it.