### PR TITLE
Add filesystem type support on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add AIX support. #133
 - Add `Cached` data to Memory #145
+- Add `SysTypeName` support on Windows #146
 
 ### Fixed
 

--- a/sigar_windows.go
+++ b/sigar_windows.go
@@ -136,16 +136,16 @@ func (self *FileSystemList) Get() error {
 		if err != nil {
 			return errors.Wrapf(err, "GetDriveType failed")
 		}
-		volumeType, err := windows.GetVolumeInfo(drive)
+		fsType, err := windows.GetFilesystemType(drive)
 		if err != nil {
-			return errors.Wrapf(err, "GetVolumeInfo failed")
+			return errors.Wrapf(err, "GetFilesystemType failed")
 		}
 
 		self.List = append(self.List, FileSystem{
 			DirName:     drive,
 			DevName:     drive,
 			TypeName:    dt.String(),
-			SysTypeName: volumeType,
+			SysTypeName: fsType,
 		})
 	}
 	return nil

--- a/sigar_windows.go
+++ b/sigar_windows.go
@@ -136,11 +136,16 @@ func (self *FileSystemList) Get() error {
 		if err != nil {
 			return errors.Wrapf(err, "GetDriveType failed")
 		}
+		volumeType, err := windows.GetVolumeInfo(drive)
+		if err != nil {
+			return errors.Wrapf(err, "GetVolumeInfo failed")
+		}
 
 		self.List = append(self.List, FileSystem{
-			DirName:  drive,
-			DevName:  drive,
-			TypeName: dt.String(),
+			DirName:     drive,
+			DevName:     drive,
+			TypeName:    dt.String(),
+			SysTypeName: volumeType,
 		})
 	}
 	return nil

--- a/sys/windows/syscall_windows.go
+++ b/sys/windows/syscall_windows.go
@@ -2,6 +2,7 @@ package windows
 
 import (
 	"fmt"
+	"strings"
 	"syscall"
 	"time"
 	"unsafe"
@@ -335,6 +336,23 @@ func GetDriveType(rootPathName string) (DriveType, error) {
 	return dt, nil
 }
 
+// GetVolumeInfo returns volume informatiom at the given root path.
+// https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getvolumeinformationw
+func GetVolumeInfo(rootPathName string) (string, error) {
+	rootPathNamePtr, err := syscall.UTF16PtrFromString(rootPathName)
+	if err != nil {
+		return "", errors.Wrapf(err, "UTF16PtrFromString failed for rootPathName=%v", rootPathName)
+	}
+
+	buffer := make([]uint16, MAX_PATH)
+	success, err := _GetVolumeInformation(rootPathNamePtr, nil, 0, nil, nil, nil, &buffer[0], MAX_PATH)
+	if !success {
+		return "", errors.Wrap(err, "GetVolumeInformationW failed")
+	}
+
+	return strings.ToLower(syscall.UTF16ToString(buffer)), nil
+}
+
 // EnumProcesses retrieves the process identifier for each process object in the
 // system. This function can return a max of 65536 PIDs. If there are more
 // processes than that then this will not return them all.
@@ -587,6 +605,7 @@ func GetTickCount64() (uptime uint64, err error) {
 //sys   _GetProcessImageFileName(handle syscall.Handle, outImageFileName *uint16, size uint32) (length uint32, err error) = psapi.GetProcessImageFileNameW
 //sys   _GetSystemTimes(idleTime *syscall.Filetime, kernelTime *syscall.Filetime, userTime *syscall.Filetime) (err error) = kernel32.GetSystemTimes
 //sys   _GetDriveType(rootPathName *uint16) (dt DriveType, err error) = kernel32.GetDriveTypeW
+//sys   _GetVolumeInformation(rootPathName *uint16, volumeName *uint16, volumeNameSize uint32, volumeSerialNumber *uint32, maximumComponentLength *uint32, fileSystemFlags *uint32, fileSystemName *uint16, fileSystemNameSize uint32) (success bool, err error) [true] = kernel32.GetVolumeInformationW
 //sys   _EnumProcesses(processIds *uint32, sizeBytes uint32, bytesReturned *uint32) (err error) = psapi.EnumProcesses
 //sys   _GetDiskFreeSpaceEx(directoryName *uint16, freeBytesAvailable *uint64, totalNumberOfBytes *uint64, totalNumberOfFreeBytes *uint64) (err error) = kernel32.GetDiskFreeSpaceExW
 //sys   _Process32First(handle syscall.Handle, processEntry32 *ProcessEntry32) (err error) = kernel32.Process32FirstW

--- a/sys/windows/syscall_windows.go
+++ b/sys/windows/syscall_windows.go
@@ -336,15 +336,15 @@ func GetDriveType(rootPathName string) (DriveType, error) {
 	return dt, nil
 }
 
-// GetVolumeInfo returns volume informatiom at the given root path.
+// GetFilesystemType returns file system type information at the given root path.
 // https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getvolumeinformationw
-func GetVolumeInfo(rootPathName string) (string, error) {
+func GetFilesystemType(rootPathName string) (string, error) {
 	rootPathNamePtr, err := syscall.UTF16PtrFromString(rootPathName)
 	if err != nil {
 		return "", errors.Wrapf(err, "UTF16PtrFromString failed for rootPathName=%v", rootPathName)
 	}
 
-	buffer := make([]uint16, MAX_PATH)
+	buffer := make([]uint16, MAX_PATH+1)
 	success, err := _GetVolumeInformation(rootPathNamePtr, nil, 0, nil, nil, nil, &buffer[0], MAX_PATH)
 	if !success {
 		return "", errors.Wrap(err, "GetVolumeInformationW failed")

--- a/sys/windows/syscall_windows_test.go
+++ b/sys/windows/syscall_windows_test.go
@@ -114,18 +114,18 @@ func TestGetDiskFreeSpaceEx(t *testing.T) {
 	}
 }
 
-func TestGetVolumeInfo(t *testing.T) {
+func TestGetFilesystemType(t *testing.T) {
 	drives, err := GetLogicalDriveStrings()
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for _, drive := range drives {
-		volumeType, err := GetVolumeInfo(drive)
+		volumeType, err := GetFilesystemType(drive)
 		if err != nil {
 			t.Fatal(err)
 		}
-		t.Logf("GetVolumeInfo: %v - %v", drive, volumeType)
+		t.Logf("GetFilesystemType: %v - %v", drive, volumeType)
 	}
 }
 

--- a/sys/windows/syscall_windows_test.go
+++ b/sys/windows/syscall_windows_test.go
@@ -114,6 +114,21 @@ func TestGetDiskFreeSpaceEx(t *testing.T) {
 	}
 }
 
+func TestGetVolumeInfo(t *testing.T) {
+	drives, err := GetLogicalDriveStrings()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, drive := range drives {
+		volumeType, err := GetVolumeInfo(drive)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("GetVolumeInfo: %v - %v", drive, volumeType)
+	}
+}
+
 func TestGetWindowsVersion(t *testing.T) {
 	ver := GetWindowsVersion()
 	assert.True(t, ver.Major >= 5)

--- a/sys/windows/zsyscall_windows.go
+++ b/sys/windows/zsyscall_windows.go
@@ -19,6 +19,7 @@ const (
 
 var (
 	errERROR_IO_PENDING error = syscall.Errno(errnoERROR_IO_PENDING)
+	errERROR_EINVAL     error = syscall.EINVAL
 )
 
 // errnoErr returns common boxed Errno values, to prevent
@@ -26,7 +27,7 @@ var (
 func errnoErr(e syscall.Errno) error {
 	switch e {
 	case 0:
-		return nil
+		return errERROR_EINVAL
 	case errnoERROR_IO_PENDING:
 		return errERROR_IO_PENDING
 	}
@@ -37,193 +38,45 @@ func errnoErr(e syscall.Errno) error {
 }
 
 var (
-	modkernel32 = windows.NewLazySystemDLL("kernel32.dll")
-	modpsapi    = windows.NewLazySystemDLL("psapi.dll")
-	modntdll    = windows.NewLazySystemDLL("ntdll.dll")
 	modadvapi32 = windows.NewLazySystemDLL("advapi32.dll")
+	modkernel32 = windows.NewLazySystemDLL("kernel32.dll")
+	modntdll    = windows.NewLazySystemDLL("ntdll.dll")
+	modpsapi    = windows.NewLazySystemDLL("psapi.dll")
 
-	procGlobalMemoryStatusEx             = modkernel32.NewProc("GlobalMemoryStatusEx")
-	procGetLogicalDriveStringsW          = modkernel32.NewProc("GetLogicalDriveStringsW")
-	procGetProcessMemoryInfo             = modpsapi.NewProc("GetProcessMemoryInfo")
-	procGetProcessImageFileNameW         = modpsapi.NewProc("GetProcessImageFileNameW")
-	procGetSystemTimes                   = modkernel32.NewProc("GetSystemTimes")
-	procGetDriveTypeW                    = modkernel32.NewProc("GetDriveTypeW")
-	procEnumProcesses                    = modpsapi.NewProc("EnumProcesses")
-	procGetDiskFreeSpaceExW              = modkernel32.NewProc("GetDiskFreeSpaceExW")
-	procProcess32FirstW                  = modkernel32.NewProc("Process32FirstW")
-	procProcess32NextW                   = modkernel32.NewProc("Process32NextW")
-	procCreateToolhelp32Snapshot         = modkernel32.NewProc("CreateToolhelp32Snapshot")
-	procNtQuerySystemInformation         = modntdll.NewProc("NtQuerySystemInformation")
-	procNtQueryInformationProcess        = modntdll.NewProc("NtQueryInformationProcess")
+	procAdjustTokenPrivileges            = modadvapi32.NewProc("AdjustTokenPrivileges")
 	procLookupPrivilegeNameW             = modadvapi32.NewProc("LookupPrivilegeNameW")
 	procLookupPrivilegeValueW            = modadvapi32.NewProc("LookupPrivilegeValueW")
-	procAdjustTokenPrivileges            = modadvapi32.NewProc("AdjustTokenPrivileges")
+	procCreateToolhelp32Snapshot         = modkernel32.NewProc("CreateToolhelp32Snapshot")
 	procFindFirstVolumeW                 = modkernel32.NewProc("FindFirstVolumeW")
 	procFindNextVolumeW                  = modkernel32.NewProc("FindNextVolumeW")
 	procFindVolumeClose                  = modkernel32.NewProc("FindVolumeClose")
-	procGetVolumePathNamesForVolumeNameW = modkernel32.NewProc("GetVolumePathNamesForVolumeNameW")
-	procReadProcessMemory                = modkernel32.NewProc("ReadProcessMemory")
+	procGetDiskFreeSpaceExW              = modkernel32.NewProc("GetDiskFreeSpaceExW")
+	procGetDriveTypeW                    = modkernel32.NewProc("GetDriveTypeW")
+	procGetLogicalDriveStringsW          = modkernel32.NewProc("GetLogicalDriveStringsW")
+	procGetSystemTimes                   = modkernel32.NewProc("GetSystemTimes")
 	procGetTickCount64                   = modkernel32.NewProc("GetTickCount64")
+	procGetVolumeInformationW            = modkernel32.NewProc("GetVolumeInformationW")
+	procGetVolumePathNamesForVolumeNameW = modkernel32.NewProc("GetVolumePathNamesForVolumeNameW")
+	procGlobalMemoryStatusEx             = modkernel32.NewProc("GlobalMemoryStatusEx")
+	procProcess32FirstW                  = modkernel32.NewProc("Process32FirstW")
+	procProcess32NextW                   = modkernel32.NewProc("Process32NextW")
+	procReadProcessMemory                = modkernel32.NewProc("ReadProcessMemory")
+	procNtQueryInformationProcess        = modntdll.NewProc("NtQueryInformationProcess")
+	procNtQuerySystemInformation         = modntdll.NewProc("NtQuerySystemInformation")
+	procEnumProcesses                    = modpsapi.NewProc("EnumProcesses")
+	procGetProcessImageFileNameW         = modpsapi.NewProc("GetProcessImageFileNameW")
+	procGetProcessMemoryInfo             = modpsapi.NewProc("GetProcessMemoryInfo")
 )
 
-func _GlobalMemoryStatusEx(buffer *MemoryStatusEx) (err error) {
-	r1, _, e1 := syscall.Syscall(procGlobalMemoryStatusEx.Addr(), 1, uintptr(unsafe.Pointer(buffer)), 0, 0)
-	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
+func _AdjustTokenPrivileges(token syscall.Token, releaseAll bool, input *byte, outputSize uint32, output *byte, requiredSize *uint32) (success bool, err error) {
+	var _p0 uint32
+	if releaseAll {
+		_p0 = 1
 	}
-	return
-}
-
-func _GetLogicalDriveStringsW(bufferLength uint32, buffer *uint16) (length uint32, err error) {
-	r0, _, e1 := syscall.Syscall(procGetLogicalDriveStringsW.Addr(), 2, uintptr(bufferLength), uintptr(unsafe.Pointer(buffer)), 0)
-	length = uint32(r0)
-	if length == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
-	return
-}
-
-func _GetProcessMemoryInfo(handle syscall.Handle, psmemCounters *ProcessMemoryCountersEx, cb uint32) (err error) {
-	r1, _, e1 := syscall.Syscall(procGetProcessMemoryInfo.Addr(), 3, uintptr(handle), uintptr(unsafe.Pointer(psmemCounters)), uintptr(cb))
-	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
-	return
-}
-
-func _GetProcessImageFileName(handle syscall.Handle, outImageFileName *uint16, size uint32) (length uint32, err error) {
-	r0, _, e1 := syscall.Syscall(procGetProcessImageFileNameW.Addr(), 3, uintptr(handle), uintptr(unsafe.Pointer(outImageFileName)), uintptr(size))
-	length = uint32(r0)
-	if length == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
-	return
-}
-
-func _GetSystemTimes(idleTime *syscall.Filetime, kernelTime *syscall.Filetime, userTime *syscall.Filetime) (err error) {
-	r1, _, e1 := syscall.Syscall(procGetSystemTimes.Addr(), 3, uintptr(unsafe.Pointer(idleTime)), uintptr(unsafe.Pointer(kernelTime)), uintptr(unsafe.Pointer(userTime)))
-	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
-	return
-}
-
-func _GetDriveType(rootPathName *uint16) (dt DriveType, err error) {
-	r0, _, e1 := syscall.Syscall(procGetDriveTypeW.Addr(), 1, uintptr(unsafe.Pointer(rootPathName)), 0, 0)
-	dt = DriveType(r0)
-	if dt == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
-	return
-}
-
-func _EnumProcesses(processIds *uint32, sizeBytes uint32, bytesReturned *uint32) (err error) {
-	r1, _, e1 := syscall.Syscall(procEnumProcesses.Addr(), 3, uintptr(unsafe.Pointer(processIds)), uintptr(sizeBytes), uintptr(unsafe.Pointer(bytesReturned)))
-	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
-	return
-}
-
-func _GetDiskFreeSpaceEx(directoryName *uint16, freeBytesAvailable *uint64, totalNumberOfBytes *uint64, totalNumberOfFreeBytes *uint64) (err error) {
-	r1, _, e1 := syscall.Syscall6(procGetDiskFreeSpaceExW.Addr(), 4, uintptr(unsafe.Pointer(directoryName)), uintptr(unsafe.Pointer(freeBytesAvailable)), uintptr(unsafe.Pointer(totalNumberOfBytes)), uintptr(unsafe.Pointer(totalNumberOfFreeBytes)), 0, 0)
-	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
-	return
-}
-
-func _Process32First(handle syscall.Handle, processEntry32 *ProcessEntry32) (err error) {
-	r1, _, e1 := syscall.Syscall(procProcess32FirstW.Addr(), 2, uintptr(handle), uintptr(unsafe.Pointer(processEntry32)), 0)
-	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
-	return
-}
-
-func _Process32Next(handle syscall.Handle, processEntry32 *ProcessEntry32) (err error) {
-	r1, _, e1 := syscall.Syscall(procProcess32NextW.Addr(), 2, uintptr(handle), uintptr(unsafe.Pointer(processEntry32)), 0)
-	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
-	return
-}
-
-func _CreateToolhelp32Snapshot(flags uint32, processID uint32) (handle syscall.Handle, err error) {
-	r0, _, e1 := syscall.Syscall(procCreateToolhelp32Snapshot.Addr(), 2, uintptr(flags), uintptr(processID), 0)
-	handle = syscall.Handle(r0)
-	if handle == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
-	return
-}
-
-func _NtQuerySystemInformation(systemInformationClass uint32, systemInformation *byte, systemInformationLength uint32, returnLength *uint32) (ntstatus uint32, err error) {
-	r0, _, e1 := syscall.Syscall6(procNtQuerySystemInformation.Addr(), 4, uintptr(systemInformationClass), uintptr(unsafe.Pointer(systemInformation)), uintptr(systemInformationLength), uintptr(unsafe.Pointer(returnLength)), 0, 0)
-	ntstatus = uint32(r0)
-	if ntstatus == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
-	return
-}
-
-func _NtQueryInformationProcess(processHandle syscall.Handle, processInformationClass uint32, processInformation *byte, processInformationLength uint32, returnLength *uint32) (ntstatus uint32, err error) {
-	r0, _, e1 := syscall.Syscall6(procNtQueryInformationProcess.Addr(), 5, uintptr(processHandle), uintptr(processInformationClass), uintptr(unsafe.Pointer(processInformation)), uintptr(processInformationLength), uintptr(unsafe.Pointer(returnLength)), 0)
-	ntstatus = uint32(r0)
-	if ntstatus == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
+	r0, _, e1 := syscall.Syscall6(procAdjustTokenPrivileges.Addr(), 6, uintptr(token), uintptr(_p0), uintptr(unsafe.Pointer(input)), uintptr(outputSize), uintptr(unsafe.Pointer(output)), uintptr(unsafe.Pointer(requiredSize)))
+	success = r0 != 0
+	if true {
+		err = errnoErr(e1)
 	}
 	return
 }
@@ -240,11 +93,7 @@ func _LookupPrivilegeName(systemName string, luid *int64, buffer *uint16, size *
 func __LookupPrivilegeName(systemName *uint16, luid *int64, buffer *uint16, size *uint32) (err error) {
 	r1, _, e1 := syscall.Syscall6(procLookupPrivilegeNameW.Addr(), 4, uintptr(unsafe.Pointer(systemName)), uintptr(unsafe.Pointer(luid)), uintptr(unsafe.Pointer(buffer)), uintptr(unsafe.Pointer(size)), 0, 0)
 	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
+		err = errnoErr(e1)
 	}
 	return
 }
@@ -266,30 +115,16 @@ func _LookupPrivilegeValue(systemName string, name string, luid *int64) (err err
 func __LookupPrivilegeValue(systemName *uint16, name *uint16, luid *int64) (err error) {
 	r1, _, e1 := syscall.Syscall(procLookupPrivilegeValueW.Addr(), 3, uintptr(unsafe.Pointer(systemName)), uintptr(unsafe.Pointer(name)), uintptr(unsafe.Pointer(luid)))
 	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
+		err = errnoErr(e1)
 	}
 	return
 }
 
-func _AdjustTokenPrivileges(token syscall.Token, releaseAll bool, input *byte, outputSize uint32, output *byte, requiredSize *uint32) (success bool, err error) {
-	var _p0 uint32
-	if releaseAll {
-		_p0 = 1
-	} else {
-		_p0 = 0
-	}
-	r0, _, e1 := syscall.Syscall6(procAdjustTokenPrivileges.Addr(), 6, uintptr(token), uintptr(_p0), uintptr(unsafe.Pointer(input)), uintptr(outputSize), uintptr(unsafe.Pointer(output)), uintptr(unsafe.Pointer(requiredSize)))
-	success = r0 != 0
-	if true {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
+func _CreateToolhelp32Snapshot(flags uint32, processID uint32) (handle syscall.Handle, err error) {
+	r0, _, e1 := syscall.Syscall(procCreateToolhelp32Snapshot.Addr(), 2, uintptr(flags), uintptr(processID), 0)
+	handle = syscall.Handle(r0)
+	if handle == 0 {
+		err = errnoErr(e1)
 	}
 	return
 }
@@ -298,11 +133,7 @@ func _FindFirstVolume(volumeName *uint16, size uint32) (handle syscall.Handle, e
 	r0, _, e1 := syscall.Syscall(procFindFirstVolumeW.Addr(), 2, uintptr(unsafe.Pointer(volumeName)), uintptr(size), 0)
 	handle = syscall.Handle(r0)
 	if handle == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
+		err = errnoErr(e1)
 	}
 	return
 }
@@ -310,11 +141,7 @@ func _FindFirstVolume(volumeName *uint16, size uint32) (handle syscall.Handle, e
 func _FindNextVolume(handle syscall.Handle, volumeName *uint16, size uint32) (err error) {
 	r1, _, e1 := syscall.Syscall(procFindNextVolumeW.Addr(), 3, uintptr(handle), uintptr(unsafe.Pointer(volumeName)), uintptr(size))
 	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
+		err = errnoErr(e1)
 	}
 	return
 }
@@ -322,11 +149,59 @@ func _FindNextVolume(handle syscall.Handle, volumeName *uint16, size uint32) (er
 func _FindVolumeClose(handle syscall.Handle) (err error) {
 	r1, _, e1 := syscall.Syscall(procFindVolumeClose.Addr(), 1, uintptr(handle), 0, 0)
 	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func _GetDiskFreeSpaceEx(directoryName *uint16, freeBytesAvailable *uint64, totalNumberOfBytes *uint64, totalNumberOfFreeBytes *uint64) (err error) {
+	r1, _, e1 := syscall.Syscall6(procGetDiskFreeSpaceExW.Addr(), 4, uintptr(unsafe.Pointer(directoryName)), uintptr(unsafe.Pointer(freeBytesAvailable)), uintptr(unsafe.Pointer(totalNumberOfBytes)), uintptr(unsafe.Pointer(totalNumberOfFreeBytes)), 0, 0)
+	if r1 == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func _GetDriveType(rootPathName *uint16) (dt DriveType, err error) {
+	r0, _, e1 := syscall.Syscall(procGetDriveTypeW.Addr(), 1, uintptr(unsafe.Pointer(rootPathName)), 0, 0)
+	dt = DriveType(r0)
+	if dt == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func _GetLogicalDriveStringsW(bufferLength uint32, buffer *uint16) (length uint32, err error) {
+	r0, _, e1 := syscall.Syscall(procGetLogicalDriveStringsW.Addr(), 2, uintptr(bufferLength), uintptr(unsafe.Pointer(buffer)), 0)
+	length = uint32(r0)
+	if length == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func _GetSystemTimes(idleTime *syscall.Filetime, kernelTime *syscall.Filetime, userTime *syscall.Filetime) (err error) {
+	r1, _, e1 := syscall.Syscall(procGetSystemTimes.Addr(), 3, uintptr(unsafe.Pointer(idleTime)), uintptr(unsafe.Pointer(kernelTime)), uintptr(unsafe.Pointer(userTime)))
+	if r1 == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func _GetTickCount64() (uptime uint64, err error) {
+	r0, _, e1 := syscall.Syscall(procGetTickCount64.Addr(), 0, 0, 0, 0)
+	uptime = uint64(r0)
+	if uptime == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func _GetVolumeInformation(rootPathName *uint16, volumeName *uint16, volumeNameSize uint32, volumeSerialNumber *uint32, maximumComponentLength *uint32, fileSystemFlags *uint32, fileSystemName *uint16, fileSystemNameSize uint32) (success bool, err error) {
+	r0, _, e1 := syscall.Syscall9(procGetVolumeInformationW.Addr(), 8, uintptr(unsafe.Pointer(rootPathName)), uintptr(unsafe.Pointer(volumeName)), uintptr(volumeNameSize), uintptr(unsafe.Pointer(volumeSerialNumber)), uintptr(unsafe.Pointer(maximumComponentLength)), uintptr(unsafe.Pointer(fileSystemFlags)), uintptr(unsafe.Pointer(fileSystemName)), uintptr(fileSystemNameSize), 0)
+	success = r0 != 0
+	if true {
+		err = errnoErr(e1)
 	}
 	return
 }
@@ -343,11 +218,31 @@ func _GetVolumePathNamesForVolumeName(volumeName string, buffer *uint16, bufferS
 func __GetVolumePathNamesForVolumeName(volumeName *uint16, buffer *uint16, bufferSize uint32, length *uint32) (err error) {
 	r1, _, e1 := syscall.Syscall6(procGetVolumePathNamesForVolumeNameW.Addr(), 4, uintptr(unsafe.Pointer(volumeName)), uintptr(unsafe.Pointer(buffer)), uintptr(bufferSize), uintptr(unsafe.Pointer(length)), 0, 0)
 	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func _GlobalMemoryStatusEx(buffer *MemoryStatusEx) (err error) {
+	r1, _, e1 := syscall.Syscall(procGlobalMemoryStatusEx.Addr(), 1, uintptr(unsafe.Pointer(buffer)), 0, 0)
+	if r1 == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func _Process32First(handle syscall.Handle, processEntry32 *ProcessEntry32) (err error) {
+	r1, _, e1 := syscall.Syscall(procProcess32FirstW.Addr(), 2, uintptr(handle), uintptr(unsafe.Pointer(processEntry32)), 0)
+	if r1 == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func _Process32Next(handle syscall.Handle, processEntry32 *ProcessEntry32) (err error) {
+	r1, _, e1 := syscall.Syscall(procProcess32NextW.Addr(), 2, uintptr(handle), uintptr(unsafe.Pointer(processEntry32)), 0)
+	if r1 == 0 {
+		err = errnoErr(e1)
 	}
 	return
 }
@@ -355,24 +250,50 @@ func __GetVolumePathNamesForVolumeName(volumeName *uint16, buffer *uint16, buffe
 func _ReadProcessMemory(handle syscall.Handle, baseAddress uintptr, buffer uintptr, size uintptr, numRead *uintptr) (err error) {
 	r1, _, e1 := syscall.Syscall6(procReadProcessMemory.Addr(), 5, uintptr(handle), uintptr(baseAddress), uintptr(buffer), uintptr(size), uintptr(unsafe.Pointer(numRead)), 0)
 	if r1 == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
+		err = errnoErr(e1)
 	}
 	return
 }
 
-func _GetTickCount64() (uptime uint64, err error) {
-	r0, _, e1 := syscall.Syscall(procGetTickCount64.Addr(), 0, 0, 0, 0)
-	uptime = uint64(r0)
-	if uptime == 0 {
-		if e1 != 0 {
-			err = errnoErr(e1)
-		} else {
-			err = syscall.EINVAL
-		}
+func _NtQueryInformationProcess(processHandle syscall.Handle, processInformationClass uint32, processInformation *byte, processInformationLength uint32, returnLength *uint32) (ntstatus uint32, err error) {
+	r0, _, e1 := syscall.Syscall6(procNtQueryInformationProcess.Addr(), 5, uintptr(processHandle), uintptr(processInformationClass), uintptr(unsafe.Pointer(processInformation)), uintptr(processInformationLength), uintptr(unsafe.Pointer(returnLength)), 0)
+	ntstatus = uint32(r0)
+	if ntstatus == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func _NtQuerySystemInformation(systemInformationClass uint32, systemInformation *byte, systemInformationLength uint32, returnLength *uint32) (ntstatus uint32, err error) {
+	r0, _, e1 := syscall.Syscall6(procNtQuerySystemInformation.Addr(), 4, uintptr(systemInformationClass), uintptr(unsafe.Pointer(systemInformation)), uintptr(systemInformationLength), uintptr(unsafe.Pointer(returnLength)), 0, 0)
+	ntstatus = uint32(r0)
+	if ntstatus == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func _EnumProcesses(processIds *uint32, sizeBytes uint32, bytesReturned *uint32) (err error) {
+	r1, _, e1 := syscall.Syscall(procEnumProcesses.Addr(), 3, uintptr(unsafe.Pointer(processIds)), uintptr(sizeBytes), uintptr(unsafe.Pointer(bytesReturned)))
+	if r1 == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func _GetProcessImageFileName(handle syscall.Handle, outImageFileName *uint16, size uint32) (length uint32, err error) {
+	r0, _, e1 := syscall.Syscall(procGetProcessImageFileNameW.Addr(), 3, uintptr(handle), uintptr(unsafe.Pointer(outImageFileName)), uintptr(size))
+	length = uint32(r0)
+	if length == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func _GetProcessMemoryInfo(handle syscall.Handle, psmemCounters *ProcessMemoryCountersEx, cb uint32) (err error) {
+	r1, _, e1 := syscall.Syscall(procGetProcessMemoryInfo.Addr(), 3, uintptr(handle), uintptr(unsafe.Pointer(psmemCounters)), uintptr(cb))
+	if r1 == 0 {
+		err = errnoErr(e1)
 	}
 	return
 }


### PR DESCRIPTION
Not entirely sure if `go generate` is supposed to generate that many changes. I ran it on the beats Windows 2019 Vagrant VM.

Adds some of the functionality necessary for https://github.com/elastic/beats/issues/22501 -- as an example, returns `ntfs` as `SysTypeName` on the Vagrant box.