### PR TITLE
cgroup: add option to override the /sys/fs/cgroup hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add method of overriding the /sys/fs/cgroup hierarchy, for reading cgroup metrics inside Docker [#148](https://github.com/elastic/gosigar/pull/148)
+
 ### Fixed
 
 ### Changed

--- a/cgroup/testdata/docker/proc/1/cgroup
+++ b/cgroup/testdata/docker/proc/1/cgroup
@@ -1,0 +1,10 @@
+10:net_prio:/docker/123
+9:perf_event:/docker/123
+8:net_cls:/docker/123
+7:freezer:/docker/123
+6:devices:/docker/123
+5:memory:/docker/123
+4:blkio:/docker/123
+3:cpuacct:/docker/123
+2:cpu:/docker/123
+1:cpuset:/docker/123


### PR DESCRIPTION
When running in Docker, paths in `/proc/<pid>/cgroup` do not
correspond to the paths under `/sys/fs/cgroup/<subsystem>/...`

Instead, the root `/sys/fs/cgroup/<subsystem>` should be
used there. Provide an option for overridding the path,
similar to https://github.com/elastic/elasticsearch/pull/22757.

I added NewReaderOptions/ReaderOptions to avoid breaking
the API, and to minimise breakage in the future.

Required for https://github.com/elastic/beats/issues/22844