### PR TITLE
Ignore unsupported derive types for GetVolumeInformation  function

### DIFF
--- a/sigar_windows.go
+++ b/sigar_windows.go
@@ -140,13 +140,14 @@ func (self *FileSystemList) Get() error {
 		if err != nil {
 			return errors.Wrapf(err, "GetFilesystemType failed")
 		}
-
-		self.List = append(self.List, FileSystem{
-			DirName:     drive,
-			DevName:     drive,
-			TypeName:    dt.String(),
-			SysTypeName: fsType,
-		})
+		if fsType != "" {
+			self.List = append(self.List, FileSystem{
+				DirName:     drive,
+				DevName:     drive,
+				TypeName:    dt.String(),
+				SysTypeName: fsType,
+			})
+		}
 	}
 	return nil
 }

--- a/sys/windows/syscall_windows.go
+++ b/sys/windows/syscall_windows.go
@@ -24,6 +24,12 @@ const (
 	PROCESS_VM_READ                   uint32 = 0x0010
 )
 
+// error codes for GetVolumeInformation function
+const (
+	ERROR_INVALID_FUNCTION syscall.Errno = 1
+	ERROR_NOT_READY        syscall.Errno = 21
+)
+
 // SizeOfRtlUserProcessParameters gives the size
 // of the RtlUserProcessParameters struct.
 const SizeOfRtlUserProcessParameters = unsafe.Sizeof(RtlUserProcessParameters{})
@@ -346,6 +352,10 @@ func GetFilesystemType(rootPathName string) (string, error) {
 
 	buffer := make([]uint16, MAX_PATH+1)
 	success, err := _GetVolumeInformation(rootPathNamePtr, nil, 0, nil, nil, nil, &buffer[0], MAX_PATH)
+	// check if CD-ROM or other type that is not supported in GetVolumeInformation function
+	if err == ERROR_NOT_READY || err == ERROR_INVALID_FUNCTION {
+		return "", nil
+	}
 	if !success {
 		return "", errors.Wrap(err, "GetVolumeInformationW failed")
 	}


### PR DESCRIPTION
Ignore unsupported derive types for GetVolumeInformation  function.
Issue related https://github.com/elastic/beats/issues/22501