### PR TITLE
feat: limited ProcFDUsage support on darwin

### DIFF
--- a/sigar_darwin_test.go
+++ b/sigar_darwin_test.go
@@ -3,15 +3,20 @@ package gosigar_test
 import (
 	"bufio"
 	"bytes"
-	"fmt"
+	"io/ioutil"
+	"os"
 	"os/exec"
 	"os/user"
+	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 
+	"github.com/elastic/gosigar"
 	sigar "github.com/elastic/gosigar"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var procinfo map[string]string
@@ -71,6 +76,65 @@ func TestDarwinProcState(t *testing.T) {
 			assert.Equal(t, 0, state.Ppid)
 		}
 	} else {
-		fmt.Println("Skipping ProcState test; run as root to test")
+		t.Skip("Skipping ProcState test; run as root to test")
 	}
+}
+
+func TestDarwinProcFDUsage(t *testing.T) {
+	t.Run("Get(pid) on current pid returns open file count", func(t *testing.T) {
+		myPid := os.Getpid()
+		fdUsage := &sigar.ProcFDUsage{}
+
+		require.NoError(t, fdUsage.Get(myPid))
+		beforeOpen := fdUsage.Open
+		f, err := ioutil.TempFile(t.TempDir(), "test-open-1")
+		require.NoError(t, err)
+		defer f.Close()
+
+		require.NoError(t, fdUsage.Get(myPid))
+		assert.Equal(t, beforeOpen+1, fdUsage.Open, "opening file increases Open count")
+
+		require.NoError(t, f.Close())
+		require.NoError(t, fdUsage.Get(myPid))
+		assert.Equal(t, beforeOpen, fdUsage.Open, "closing file decreases Open count")
+	})
+	t.Run("Get(pid) on current pid returns rlimit", func(t *testing.T) {
+		myPid := os.Getpid()
+		fdUsage := &sigar.ProcFDUsage{}
+		hardLim, softLim := getRlimitViaShell(t)
+
+		require.NoError(t, fdUsage.Get(myPid))
+		assert.Equal(t, hardLim, fdUsage.HardLimit)
+		assert.Equal(t, softLim, fdUsage.SoftLimit)
+
+	})
+	t.Run("Get(pid) on another process returns an error", func(t *testing.T) {
+		fdUsage := &sigar.ProcFDUsage{}
+		otherPid := os.Getpid() + 10
+		err := fdUsage.Get(otherPid)
+		require.Error(t, err)
+		assert.Equal(t, gosigar.ErrNotImplemented{runtime.GOOS}, err)
+	})
+}
+
+func getRlimitViaShell(t *testing.T) (uint64, uint64) {
+	out, err := exec.Command("/bin/sh", "-c", "ulimit -n -H").Output()
+	require.NoError(t, err)
+	hardLimit, err := parseRlimitOutput(string(out))
+	require.NoError(t, err)
+
+	out, err = exec.Command("/bin/sh", "-c", "ulimit -n -S").Output()
+	require.NoError(t, err)
+	softLimit, err := parseRlimitOutput(string(out))
+	require.NoError(t, err)
+
+	return hardLimit, softLimit
+}
+
+func parseRlimitOutput(output string) (uint64, error) {
+	output = strings.TrimSpace(output)
+	if output == "unlimited" {
+		return syscall.RLIM_INFINITY, nil
+	}
+	return strconv.ParseUint(output, 10, 64)
 }


### PR DESCRIPTION
This adds support for ProcFDUsage on darwin when the requested PID
matches that of the current process.

On MacOS, while you can get the open file descriptors for other
processes (via `proc_pidinfo`), I don't know of a clean way to get the
current rlimit data for another process.

However, for the current process, we can retrieve the rlimits via the
`getrlimit` system call.

I've used /dev/fd to count open files rather than `proc_pidinfo`
because I think the code is a bit more straight forward than the
under-documented `proc_pidinfo` call.

It's totally understandable if you would prefer to avoid this kind
of conditional behavior.