### PR TITLE
chore(ci): move to the right CI folder

### DIFF
--- a/.ci/jobs/folders.yml
+++ b/.ci/jobs/folders.yml
@@ -1,0 +1,10 @@
+---
+#https://docs.openstack.org/infra/jenkins-job-builder/project_folder.html
+- job:
+    name: Library
+    description: Library related Jobs
+    project-type: folder
+
+- view:
+    name: Library
+    view-type: list

--- a/.ci/jobs/main.yml
+++ b/.ci/jobs/main.yml
@@ -1,6 +1,6 @@
 ---
 - job:
-    name: Beats/gosigar
+    name: Library/gosigar
     display-name: Go sigar
     description: Jenkins pipeline for Go sigar is a golang implementation of the sigar API.
     view: Beats


### PR DESCRIPTION
## What is this PR doing?
It defines the right directory at the JJBB level

## Why is it important?
Consistency, as other Go libs live in the target directory.

## Related issues
- Closes #162 

## Follows-up
- [ ] Manual remove the old CI job from Jenkins UI