### PR TITLE
Handle ERROR_INVALID_PARAMETER error for GetVolumeInformationW win32 api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix again unsupported devices for filesystem. [#159](https://github.com/elastic/gosigar/pull/159)
+- Fix again unsupported devices for filesystem. [#164](https://github.com/elastic/gosigar/pull/164)
 
 ## [0.14.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [0.14.2]
+
+### Fixed
+
+- Fix again unsupported devices for filesystem. [#159](https://github.com/elastic/gosigar/pull/159)
+
 ## [0.14.1]
 
 ### Fixed

--- a/sigar_windows.go
+++ b/sigar_windows.go
@@ -130,35 +130,23 @@ func (self *FileSystemList) Get() error {
 	if err != nil {
 		return errors.Wrap(err, "GetAccessPaths failed")
 	}
-
 	for _, drive := range drives {
 		dt, err := windows.GetDriveType(drive)
 		if err != nil {
 			return errors.Wrapf(err, "GetDriveType failed")
 		}
-		// GetFilesystemType will fail for external drives like CD-ROM or other type with error codes as ERROR_NOT_READY. ERROR_INVALID_FUNCTION, ERROR_INVALID_PARAMETER, we will do the best effort to retrieve the system type, else value is empty
-		fsType, subErr := windows.GetFilesystemType(drive)
+		fsType, err := windows.GetFilesystemType(drive)
 		if err != nil {
 			return errors.Wrapf(err, "GetFilesystemType failed")
 		}
-		fs := FileSystem{
-			DirName:  drive,
-			DevName:  drive,
-			TypeName: dt.String(),
-		}
-		if fsType != "" {
-			fs.SysTypeName = fsType
-		}
-		self.List = append(self.List, fs)
-		if subErr != nil {
-			if err != nil {
-				err = errors.Wrap(err, subErr.Error())
-			} else {
-				err = subErr
-			}
-		}
+		self.List = append(self.List, FileSystem{
+			DirName:     drive,
+			DevName:     drive,
+			TypeName:    dt.String(),
+			SysTypeName: fsType,
+		})
 	}
-	return err
+	return nil
 }
 
 // Get retrieves a list of all process identifiers (PIDs) in the system.

--- a/sigar_windows.go
+++ b/sigar_windows.go
@@ -136,20 +136,29 @@ func (self *FileSystemList) Get() error {
 		if err != nil {
 			return errors.Wrapf(err, "GetDriveType failed")
 		}
-		fsType, err := windows.GetFilesystemType(drive)
+		// GetFilesystemType will fail for external drives like CD-ROM or other type with error codes as ERROR_NOT_READY. ERROR_INVALID_FUNCTION, ERROR_INVALID_PARAMETER, we will do the best effort to retrieve the system type, else value is empty
+		fsType, subErr := windows.GetFilesystemType(drive)
 		if err != nil {
 			return errors.Wrapf(err, "GetFilesystemType failed")
 		}
+		fs := FileSystem{
+			DirName:  drive,
+			DevName:  drive,
+			TypeName: dt.String(),
+		}
 		if fsType != "" {
-			self.List = append(self.List, FileSystem{
-				DirName:     drive,
-				DevName:     drive,
-				TypeName:    dt.String(),
-				SysTypeName: fsType,
-			})
+			fs.SysTypeName = fsType
+		}
+		self.List = append(self.List, fs)
+		if subErr != nil {
+			if err != nil {
+				err = errors.Wrap(err, subErr.Error())
+			} else {
+				err = subErr
+			}
 		}
 	}
-	return nil
+	return err
 }
 
 // Get retrieves a list of all process identifiers (PIDs) in the system.

--- a/sys/windows/syscall_windows.go
+++ b/sys/windows/syscall_windows.go
@@ -349,15 +349,11 @@ func GetFilesystemType(rootPathName string) (string, error) {
 	if err != nil {
 		return "", errors.Wrapf(err, "UTF16PtrFromString failed for rootPathName=%v", rootPathName)
 	}
-
 	buffer := make([]uint16, MAX_PATH+1)
 	success, err := _GetVolumeInformation(rootPathNamePtr, nil, 0, nil, nil, nil, &buffer[0], MAX_PATH)
-	// check if CD-ROM or other type that is not supported in GetVolumeInformation function
-	if err == ERROR_NOT_READY || err == ERROR_INVALID_FUNCTION {
-		return "", nil
-	}
+	// _GetVolumeInformation will fail for external drives like CD-ROM or other type with error codes as ERROR_NOT_READY. ERROR_INVALID_FUNCTION, ERROR_INVALID_PARAMETER, these types of errors will be handled in the main function
 	if !success {
-		return "", errors.Wrap(err, "GetVolumeInformationW failed")
+		return "", errors.Wrapf(err, "GetVolumeInformationW failed on disk %s", rootPathName)
 	}
 
 	return strings.ToLower(syscall.UTF16ToString(buffer)), nil


### PR DESCRIPTION
similar to https://github.com/elastic/gosigar/pull/159
GetVolumeInformation will fail for external drives like CD-ROM or other type with error codes as ERROR_NOT_READY. ERROR_INVALID_FUNCTION, ERROR_INVALID_PARAMETER and could be others.

The PR will report error in the logs but ignore it and move further. We consider retrieving filesystem type best efforts.
Since we introduced this calculation we are getting too many issues related to external drives, so we need to decide on one of the following behaviors:
- revert https://github.com/elastic/beats/issues/22501 which is causing these scenarios
- report error and ignore it (this is what this PR is doing, we need to handle it on the helper.go side in the beats code)
- ignore error, no report in the logs since it complicates code by adding checks for this error occurrence

@jsoriano have we dealt with anything similar before? @fearful-symmetry which option would you go for? 


